### PR TITLE
 #20 - Support for time zones other than GMT (#22)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,7 @@
 					<format>xml</format>
 					<maxmem>256m</maxmem>
 					<aggregate>true</aggregate>
+					<check/>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/src/main/java/org/exparity/hamcrest/date/DateMatchers.java
+++ b/src/main/java/org/exparity/hamcrest/date/DateMatchers.java
@@ -1,43 +1,38 @@
 package org.exparity.hamcrest.date;
 
-import static java.time.DayOfWeek.*;
-import static java.time.Month.*;
-import static java.time.ZoneId.systemDefault;
-import static java.util.Arrays.asList;
+import static java.time.DayOfWeek.FRIDAY;
+import static java.time.DayOfWeek.MONDAY;
+import static java.time.DayOfWeek.SATURDAY;
+import static java.time.DayOfWeek.SUNDAY;
+import static java.time.DayOfWeek.THURSDAY;
+import static java.time.DayOfWeek.TUESDAY;
+import static java.time.DayOfWeek.WEDNESDAY;
+import static java.time.Month.APRIL;
+import static java.time.Month.AUGUST;
+import static java.time.Month.DECEMBER;
+import static java.time.Month.FEBRUARY;
+import static java.time.Month.JANUARY;
+import static java.time.Month.JULY;
+import static java.time.Month.JUNE;
+import static java.time.Month.MARCH;
+import static java.time.Month.MAY;
+import static java.time.Month.NOVEMBER;
+import static java.time.Month.OCTOBER;
+import static java.time.Month.SEPTEMBER;
 
-import java.time.DayOfWeek;
-import java.time.LocalDate;
-import java.time.Month;
-import java.time.ZoneId;
+import java.time.*;
 import java.time.temporal.ChronoField;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.Temporal;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
-import org.exparity.hamcrest.date.core.IsAfter;
-import org.exparity.hamcrest.date.core.IsBefore;
-import org.exparity.hamcrest.date.core.IsDayOfMonth;
-import org.exparity.hamcrest.date.core.IsDayOfWeek;
-import org.exparity.hamcrest.date.core.IsHour;
-import org.exparity.hamcrest.date.core.IsLeapYear;
-import org.exparity.hamcrest.date.core.IsMaximum;
-import org.exparity.hamcrest.date.core.IsMillisecond;
-import org.exparity.hamcrest.date.core.IsMinimum;
-import org.exparity.hamcrest.date.core.IsMinute;
-import org.exparity.hamcrest.date.core.IsMonth;
-import org.exparity.hamcrest.date.core.IsSame;
-import org.exparity.hamcrest.date.core.IsSameDay;
-import org.exparity.hamcrest.date.core.IsSameOrAfter;
-import org.exparity.hamcrest.date.core.IsSameOrBefore;
-import org.exparity.hamcrest.date.core.IsSecond;
-import org.exparity.hamcrest.date.core.IsWithin;
-import org.exparity.hamcrest.date.core.IsYear;
+import org.exparity.hamcrest.date.core.*;
 import org.exparity.hamcrest.date.core.format.DateFormatter;
 import org.exparity.hamcrest.date.core.format.DatePartFormatter;
 import org.exparity.hamcrest.date.core.wrapper.DateWrapper;
-import org.hamcrest.Matcher;
+import org.exparity.hamcrest.date.core.wrapper.FieldDateWrapper;
 
 /**
  * Static factory for creating {@link org.hamcrest.Matcher} instances for comparing dates
@@ -57,8 +52,8 @@ public abstract class DateMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<Date> after(final Date date) {
-        return new IsAfter<Date>(new DateWrapper(date), new DateFormatter());
+    public static DateMatcher<Date> after(final Date date) {
+        return new IsAfter<>(new DateWrapper(date), new DateFormatter());
     }
 
     /**
@@ -74,7 +69,7 @@ public abstract class DateMatchers {
      * @deprecated Use {@link #after(LocalDate)}
      */
     @Deprecated
-    public static Matcher<Date> after(final DayMonthYear date) {
+    public static DateMatcher<Date> after(final DayMonthYear date) {
         return after(date.toLocalDate());
     }
 
@@ -89,8 +84,8 @@ public abstract class DateMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<Date> after(final LocalDate date) {
-        return new IsAfter<Date>(new DateWrapper(date), new DateFormatter());
+    public static DateMatcher<Date> after(final LocalDate date) {
+        return new IsAfter<>(new DateWrapper(date), new DateFormatter());
     }
 
     /**
@@ -108,8 +103,8 @@ public abstract class DateMatchers {
      * @deprecated Use {@link #after(int, Month, int)}
      */
     @Deprecated
-    public static Matcher<Date> after(final int year, final Months month, final int day) {
-        return new IsAfter<Date>(new DateWrapper(year, month.month(), day), new DateFormatter());
+    public static DateMatcher<Date> after(final int year, final Months month, final int day) {
+        return new IsAfter<>(new DateWrapper(year, month.month(), day), new DateFormatter());
     }
 
     /**
@@ -125,8 +120,8 @@ public abstract class DateMatchers {
      * @param month the month against which the examined date is checked
      * @param day the day of the month against which the examined date is checked
      */
-    public static Matcher<Date> after(final int year, final Month month, final int day) {
-        return new IsAfter<Date>(new DateWrapper(year, month, day), new DateFormatter());
+    public static DateMatcher<Date> after(final int year, final Month month, final int day) {
+        return new IsAfter<>(new DateWrapper(year, month, day), new DateFormatter());
     }
 
     /**
@@ -140,14 +135,14 @@ public abstract class DateMatchers {
      *
      * @param year the year against which the examined date is checked
      * @param month the month against which the examined date is checked
-     * @param day the day of the month against which the examined date is checked
+     * @param dayOfMonth the day of the month against which the examined date is checked
      * @param hour the hour of the day against which the examined date is checked
      * @param minute the minute of the hour against which the examined date is checked
      * @param second the second of the minute against which the examined date is checked
      * @deprecated Use {@link #after(int, Month, int, int, int, int)}
      */
     @Deprecated
-    public static Matcher<Date> after(final int year,
+    public static DateMatcher<Date> after(final int year,
             final Months month,
             final int dayOfMonth,
             final int hour,
@@ -167,18 +162,18 @@ public abstract class DateMatchers {
      *
      * @param year the year against which the examined date is checked
      * @param month the month against which the examined date is checked
-     * @param day the day of the month against which the examined date is checked
+     * @param dayOfMonth the day of the month against which the examined date is checked
      * @param hour the hour of the day against which the examined date is checked
      * @param minute the minute of the hour against which the examined date is checked
      * @param second the second of the minute against which the examined date is checked
      */
-    public static Matcher<Date> after(final int year,
+    public static DateMatcher<Date> after(final int year,
             final Month month,
             final int dayOfMonth,
             final int hour,
             final int minute,
             final int second) {
-        return new IsAfter<Date>(new DateWrapper(year, month, dayOfMonth, hour, minute, second), new DateFormatter());
+        return new IsAfter<>(new DateWrapper(year, month, dayOfMonth, hour, minute, second), new DateFormatter());
     }
 
     /**
@@ -192,8 +187,8 @@ public abstract class DateMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<Date> before(final Date date) {
-        return new IsBefore<Date>(new DateWrapper(date), new DateFormatter());
+    public static DateMatcher<Date> before(final Date date) {
+        return new IsBefore<>(new DateWrapper(date), new DateFormatter());
     }
 
     /**
@@ -207,8 +202,8 @@ public abstract class DateMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<Date> before(final LocalDate date) {
-        return new IsBefore<Date>(new DateWrapper(date), new DateFormatter());
+    public static DateMatcher<Date> before(final LocalDate date) {
+        return new IsBefore<>(new DateWrapper(date), new DateFormatter());
     }
 
     /**
@@ -224,7 +219,7 @@ public abstract class DateMatchers {
      * @deprecated Use {@link #before(LocalDate)}
      */
     @Deprecated
-    public static Matcher<Date> before(final DayMonthYear date) {
+    public static DateMatcher<Date> before(final DayMonthYear date) {
         return before(date.toLocalDate());
     }
 
@@ -243,8 +238,8 @@ public abstract class DateMatchers {
      * @deprecated Use {@link #before(int, Month, int)}
      */
     @Deprecated
-    public static Matcher<Date> before(final int year, final Months month, final int dayOfMonth) {
-        return new IsBefore<Date>(new DateWrapper(year, month.month(), dayOfMonth), new DateFormatter());
+    public static DateMatcher<Date> before(final int year, final Months month, final int dayOfMonth) {
+        return new IsBefore<>(new DateWrapper(year, month.month(), dayOfMonth), new DateFormatter());
     }
 
     /**
@@ -260,8 +255,8 @@ public abstract class DateMatchers {
      * @param month the month against which the examined date is checked
      * @param dayOfMonth the day of the month against which the examined date is checked
      */
-    public static Matcher<Date> before(final int year, final Month month, final int dayOfMonth) {
-        return new IsBefore<Date>(new DateWrapper(year, month, dayOfMonth), new DateFormatter());
+    public static DateMatcher<Date> before(final int year, final Month month, final int dayOfMonth) {
+        return new IsBefore<>(new DateWrapper(year, month, dayOfMonth), new DateFormatter());
     }
 
     /**
@@ -275,14 +270,14 @@ public abstract class DateMatchers {
      *
      * @param year the year against which the examined date is checked
      * @param month the month against which the examined date is checked
-     * @param day the day of the month against which the examined date is checked
+     * @param dayOfMonth the day of the month against which the examined date is checked
      * @param hour the hour of the day against which the examined date is checked
      * @param minute the minute of the hour against which the examined date is checked
      * @param second the second of the minute against which the examined date is checked
      * @deprecated Use {@link #before(int, Month, int, int, int, int)}
      */
     @Deprecated
-    public static Matcher<Date> before(final int year,
+    public static DateMatcher<Date> before(final int year,
             final Months month,
             final int dayOfMonth,
             final int hour,
@@ -302,18 +297,18 @@ public abstract class DateMatchers {
      *
      * @param year the year against which the examined date is checked
      * @param month the month against which the examined date is checked
-     * @param day the day of the month against which the examined date is checked
+     * @param dayOfMonth the day of the month against which the examined date is checked
      * @param hour the hour of the day against which the examined date is checked
      * @param minute the minute of the hour against which the examined date is checked
      * @param second the second of the minute against which the examined date is checked
      */
-    public static Matcher<Date> before(final int year,
+    public static DateMatcher<Date> before(final int year,
             final Month month,
             final int dayOfMonth,
             final int hour,
             final int minute,
             final int second) {
-        return new IsBefore<Date>(new DateWrapper(year, month, dayOfMonth, hour, minute, second), new DateFormatter());
+        return new IsBefore<>(new DateWrapper(year, month, dayOfMonth, hour, minute, second), new DateFormatter());
     }
 
     /**
@@ -327,7 +322,7 @@ public abstract class DateMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<Date> sameDayOfWeek(final Date date) {
+    public static DateMatcher<Date> sameDayOfWeek(final Date date) {
         return isDayOfWeek(DayOfWeek.from(date.toInstant().atZone(ZoneId.systemDefault())));
     }
 
@@ -340,12 +335,12 @@ public abstract class DateMatchers {
      * assertThat(myDate, isDayOfWeek(Weekdays.MONDAY))
      * </pre>
      *
-     * @param weekday the reference weekday against which the examined date is checked
+     * @param dayOfWeek the reference weekday against which the examined date is checked
      * @deprecated Use {@link #isDayOfWeek(DayOfWeek...)}
      */
     @Deprecated
-    public static Matcher<Date> isDayOfWeek(final Weekdays dayOfWeek) {
-        return new IsDayOfWeek<Date>(asList(dayOfWeek.getAsDayOfWeek()), DateMatchers::dateToZoneDateTime);
+    public static DateMatcher<Date> isDayOfWeek(final Weekdays dayOfWeek) {
+        return isDayOfWeek(dayOfWeek.getAsDayOfWeek());
     }
 
     /**
@@ -357,10 +352,31 @@ public abstract class DateMatchers {
      * assertThat(myDate, isDayOfWeek(DayOfWeek.MONDAY))
      * </pre>
      *
-     * @param weekday the reference weekday against which the examined date is checked
+     * @param dayOfWeek the reference weekday against which the examined date is checked
      */
-    public static Matcher<Date> isDayOfWeek(final DayOfWeek... daysOfWeek) {
-        return new IsDayOfWeek<Date>(Arrays.asList(daysOfWeek), DateMatchers::dateToZoneDateTime);
+    public static DateMatcher<Date> isDayOfWeek(final DayOfWeek dayOfWeek) {
+      return new IsDayOfWeek<>(
+          new FieldDateWrapper(dayOfWeek.getValue(), ChronoField.DAY_OF_WEEK),
+          (d, z) -> d.toInstant().atZone(z).get(ChronoField.DAY_OF_WEEK)
+      );
+    }
+
+    /**
+     * Creates a matcher that matches when the examined date is on the same day of the week as any of the supplied days
+     * <p/>
+     * For example:
+     *
+     * <pre>
+     * assertThat(myDate, isDayOfWeek(DayOfWeek.MONDAY, DayOfWeek.TUESDAY))
+     * </pre>
+     *
+     * @param daysOfWeek the reference weekdays against which the examined date is checked
+     */
+    public static DateMatcher<Date> isDayOfWeek(final DayOfWeek... daysOfWeek) {
+      return new AnyOf<>(
+          Stream.of(daysOfWeek).map(DateMatchers::isDayOfWeek),
+          (d, z) -> "the date is on a " + d.toInstant().atZone(z).getDayOfWeek().name().toLowerCase()
+      );
     }
 
     /**
@@ -374,8 +390,11 @@ public abstract class DateMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<Date> sameDayOfMonth(final Date date) {
-        return isDayOfMonth(extractField(date, ChronoField.DAY_OF_MONTH));
+    public static DateMatcher<Date> sameDayOfMonth(final Date date) {
+      return new IsDayOfMonth<>(
+          new FieldDateWrapper(date, ChronoField.DAY_OF_MONTH),
+          (d, z) -> d.toInstant().atZone(z).get(ChronoField.DAY_OF_MONTH)
+      );
     }
 
     /**
@@ -387,10 +406,13 @@ public abstract class DateMatchers {
      * assertThat(myDate, isDayOfMonth(4))
      * </pre>
      *
-     * @param date the expected day of the month
+     * @param dayOfMonth the expected day of the month
      */
-    public static Matcher<Date> isDayOfMonth(final int dayOfMonth) {
-        return new IsDayOfMonth<Date>(dayOfMonth, DateMatchers::dateToZoneDateTime);
+    public static DateMatcher<Date> isDayOfMonth(final int dayOfMonth) {
+        return new IsDayOfMonth<>(
+            new FieldDateWrapper(dayOfMonth, ChronoField.DAY_OF_MONTH),
+          (d, z) -> d.toInstant().atZone(z).get(ChronoField.DAY_OF_MONTH)
+      );
     }
 
     /**
@@ -404,8 +426,8 @@ public abstract class DateMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<Date> sameDay(final Date date) {
-        return new IsSameDay<Date>(new DateWrapper(date), new DateFormatter());
+    public static DateMatcher<Date> sameDay(final Date date) {
+        return new IsSameDay<>(new DateWrapper(date, ChronoUnit.DAYS), new DateFormatter());
     }
 
     /**
@@ -421,7 +443,7 @@ public abstract class DateMatchers {
      * @deprecated Use {@link #sameDay(LocalDate)}
      */
     @Deprecated
-    public static Matcher<Date> sameDay(final DayMonthYear date) {
+    public static DateMatcher<Date> sameDay(final DayMonthYear date) {
         return sameDay(date.toLocalDate());
     }
 
@@ -436,8 +458,8 @@ public abstract class DateMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<Date> sameDay(final LocalDate date) {
-        return new IsSameDay<Date>(new DateWrapper(date), new DateFormatter());
+    public static DateMatcher<Date> sameDay(final LocalDate date) {
+        return new IsSameDay<>(new DateWrapper(date), new DateFormatter());
     }
 
     /**
@@ -455,7 +477,7 @@ public abstract class DateMatchers {
      * @deprecated Use {@link #isDay(int, Month, int)}
      */
     @Deprecated
-    public static Matcher<Date> sameDay(final int year, final Months month, final int day) {
+    public static DateMatcher<Date> sameDay(final int year, final Months month, final int day) {
         return isDay(year, month.month(), day);
     }
 
@@ -472,7 +494,7 @@ public abstract class DateMatchers {
      * @param month the reference month against which the examined date is checked
      * @param year the reference year against which the examined date is checked
      */
-    public static Matcher<Date> isDay(final int year, final Month month, final int dayOfMonth) {
+    public static DateMatcher<Date> isDay(final int year, final Month month, final int dayOfMonth) {
         return sameDay(LocalDate.of(year, month, dayOfMonth));
     }
 
@@ -489,7 +511,7 @@ public abstract class DateMatchers {
      * @deprecated Use {@link #sameHourOfDay(Date)} instead
      */
     @Deprecated
-    public static Matcher<Date> sameHour(final Date date) {
+    public static DateMatcher<Date> sameHour(final Date date) {
         return sameHourOfDay(date);
     }
 
@@ -504,8 +526,11 @@ public abstract class DateMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<Date> sameHourOfDay(final Date date) {
-        return isHour(extractField(date, ChronoField.HOUR_OF_DAY));
+    public static DateMatcher<Date> sameHourOfDay(final Date date) {
+        return new IsHour<>(
+            new FieldDateWrapper(date, ChronoField.HOUR_OF_DAY),
+            (d, z) -> d.toInstant().atZone(z).get(ChronoField.HOUR_OF_DAY)
+        );
     }
 
     /**
@@ -520,9 +545,8 @@ public abstract class DateMatchers {
      * @param hour the reference hour against which the examined date is checked
      * @deprecated Use {@link #isHour(int)} instead
      */
-
     @Deprecated
-    public static Matcher<Date> sameHour(final int hour) {
+    public static DateMatcher<Date> sameHour(final int hour) {
         return isHour(hour);
     }
 
@@ -538,8 +562,11 @@ public abstract class DateMatchers {
      * @param hour the reference hour against which the examined date is checked
      */
 
-    public static Matcher<Date> isHour(final int hour) {
-        return new IsHour<Date>(hour, DateMatchers::dateToZoneDateTime);
+    public static DateMatcher<Date> isHour(final int hour) {
+        return new IsHour<>(
+            new FieldDateWrapper(hour, ChronoField.HOUR_OF_DAY),
+            (d, z) -> d.toInstant().atZone(z).get(ChronoField.HOUR_OF_DAY)
+        );
     }
 
     /**
@@ -553,8 +580,8 @@ public abstract class DateMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<Date> sameInstant(final Date date) {
-        return new IsSame<Date>(new DateWrapper(date), new DateFormatter());
+    public static DateMatcher<Date> sameInstant(final Date date) {
+        return new IsSame<>(new DateWrapper(date), new DateFormatter());
     }
 
     /**
@@ -569,8 +596,8 @@ public abstract class DateMatchers {
      *
      * @param timestamp the time as milliseconds since the Unix epoch time
      */
-    public static Matcher<Date> sameInstant(final long timestamp) {
-        return new IsSame<Date>(new DateWrapper(new Date(timestamp)), new DateFormatter());
+    public static DateMatcher<Date> sameInstant(final long timestamp) {
+        return new IsSame<>(new DateWrapper(new Date(timestamp)), new DateFormatter());
     }
 
     /**
@@ -584,7 +611,7 @@ public abstract class DateMatchers {
      *
      * @param year the year against which the examined date is checked
      * @param month the month against which the examined date is checked
-     * @param day the day of the month against which the examined date is checked
+     * @param dayOfMonth the day of the month against which the examined date is checked
      * @param hour the hour of the day against which the examined date is checked
      * @param minute the minute of the hour against which the examined date is checked
      * @param second the second of the minute against which the examined date is checked
@@ -592,7 +619,7 @@ public abstract class DateMatchers {
      * @deprecated Use {@link #isInstant(int, Month, int, int, int, int, int)}
      */
     @Deprecated
-    public static Matcher<Date> sameInstant(final int year,
+    public static DateMatcher<Date> sameInstant(final int year,
             final Months month,
             final int dayOfMonth,
             final int hour,
@@ -613,21 +640,21 @@ public abstract class DateMatchers {
      *
      * @param year the year against which the examined date is checked
      * @param month the month against which the examined date is checked
-     * @param day the day of the month against which the examined date is checked
+     * @param dayOfMonth the day of the month against which the examined date is checked
      * @param hour the hour of the day against which the examined date is checked
      * @param minute the minute of the hour against which the examined date is checked
      * @param second the second of the minute against which the examined date is checked
      * @param milliseconds the milliseconds of the second against which the examined date is checked
      */
-    public static Matcher<Date> isInstant(final int year,
+    public static DateMatcher<Date> isInstant(final int year,
             final Month month,
             final int dayOfMonth,
             final int hour,
             final int minute,
             final int second,
             final int milliseconds) {
-        return new IsSame<Date>(new DateWrapper(year, month, dayOfMonth, hour, minute, second, milliseconds),
-                new DateFormatter());
+        return new IsSame<>(new DateWrapper(year, month, dayOfMonth, hour, minute, second, milliseconds),
+            new DateFormatter());
     }
 
     /**
@@ -641,8 +668,8 @@ public abstract class DateMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<Date> sameOrBefore(final Date date) {
-        return new IsSameOrBefore<Date>(new DateWrapper(date), new DateFormatter());
+    public static DateMatcher<Date> sameOrBefore(final Date date) {
+        return new IsSameOrBefore<>(new DateWrapper(date), new DateFormatter());
     }
 
     /**
@@ -656,8 +683,8 @@ public abstract class DateMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<Date> sameOrBefore(final LocalDate date) {
-        return new IsSameOrBefore<Date>(new DateWrapper(date), new DateFormatter());
+    public static DateMatcher<Date> sameOrBefore(final LocalDate date) {
+        return new IsSameOrBefore<>(new DateWrapper(date), new DateFormatter());
     }
 
     /**
@@ -673,7 +700,7 @@ public abstract class DateMatchers {
      * @deprecated Use {@link #sameOrBefore(LocalDate)}
      */
     @Deprecated
-    public static Matcher<Date> sameOrBefore(final DayMonthYear date) {
+    public static DateMatcher<Date> sameOrBefore(final DayMonthYear date) {
         return sameOrBefore(date.toLocalDate());
     }
 
@@ -693,7 +720,7 @@ public abstract class DateMatchers {
      * @deprecated Use {@link #sameOrBefore(int, Month, int)}
      */
     @Deprecated
-    public static Matcher<Date> sameOrBefore(final int year, final Months month, final int dayOfMonth) {
+    public static DateMatcher<Date> sameOrBefore(final int year, final Months month, final int dayOfMonth) {
         return sameOrBefore(year, month.month(), dayOfMonth);
     }
 
@@ -711,8 +738,8 @@ public abstract class DateMatchers {
      * @param month the month against which the examined date is checked
      * @param dayOfMonth the day of the month against which the examined date is checked
      */
-    public static Matcher<Date> sameOrBefore(final int year, final Month month, final int dayOfMonth) {
-        return new IsSameOrBefore<Date>(new DateWrapper(LocalDate.of(year, month, dayOfMonth)), new DateFormatter());
+    public static DateMatcher<Date> sameOrBefore(final int year, final Month month, final int dayOfMonth) {
+        return new IsSameOrBefore<>(new DateWrapper(LocalDate.of(year, month, dayOfMonth)), new DateFormatter());
     }
 
     /**
@@ -734,7 +761,7 @@ public abstract class DateMatchers {
      * @deprecated See {@link #sameOrBefore(int, Month, int, int, int, int)}
      */
     @Deprecated
-    public static Matcher<Date> sameOrBefore(final int year,
+    public static DateMatcher<Date> sameOrBefore(final int year,
             final Months month,
             final int dayOfMonth,
             final int hour,
@@ -761,14 +788,14 @@ public abstract class DateMatchers {
      * @param second the second of the minute against which the examined date is checked
      */
 
-    public static Matcher<Date> sameOrBefore(final int year,
+    public static DateMatcher<Date> sameOrBefore(final int year,
             final Month month,
             final int dayOfMonth,
             final int hour,
             final int minute,
             final int second) {
-        return new IsSameOrBefore<Date>(new DateWrapper(year, month, dayOfMonth, hour, minute, second),
-                new DateFormatter());
+        return new IsSameOrBefore<>(new DateWrapper(year, month, dayOfMonth, hour, minute, second),
+            new DateFormatter());
     }
 
     /**
@@ -782,8 +809,8 @@ public abstract class DateMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<Date> sameOrAfter(final Date date) {
-        return new IsSameOrAfter<Date>(new DateWrapper(date), new DateFormatter());
+    public static DateMatcher<Date> sameOrAfter(final Date date) {
+        return new IsSameOrAfter<>(new DateWrapper(date), new DateFormatter());
     }
 
     /**
@@ -797,8 +824,8 @@ public abstract class DateMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<Date> sameOrAfter(final LocalDate date) {
-        return new IsSameOrAfter<Date>(new DateWrapper(date), new DateFormatter());
+    public static DateMatcher<Date> sameOrAfter(final LocalDate date) {
+        return new IsSameOrAfter<>(new DateWrapper(date), new DateFormatter());
     }
 
     /**
@@ -814,7 +841,7 @@ public abstract class DateMatchers {
      * @deprecated Use {@link #sameOrAfter(LocalDate)}
      */
     @Deprecated
-    public static Matcher<Date> sameOrAfter(final DayMonthYear date) {
+    public static DateMatcher<Date> sameOrAfter(final DayMonthYear date) {
         return sameOrAfter(date.toLocalDate());
     }
 
@@ -833,7 +860,7 @@ public abstract class DateMatchers {
      * @deprecated Use {@link #sameOrAfter(int, Month, int)
      */
     @Deprecated
-    public static Matcher<Date> sameOrAfter(final int year, final Months month, final int dayOfMonth) {
+    public static DateMatcher<Date> sameOrAfter(final int year, final Months month, final int dayOfMonth) {
         return sameOrAfter(year, month.month(), dayOfMonth);
     }
 
@@ -850,8 +877,8 @@ public abstract class DateMatchers {
      * @param month the month against which the examined date is checked
      * @param dayOfMonth the day of the month against which the examined date is checked
      */
-    public static Matcher<Date> sameOrAfter(final int year, final Month month, final int dayOfMonth) {
-        return new IsSameOrAfter<Date>(new DateWrapper(year, month, dayOfMonth), new DateFormatter());
+    public static DateMatcher<Date> sameOrAfter(final int year, final Month month, final int dayOfMonth) {
+        return new IsSameOrAfter<>(new DateWrapper(year, month, dayOfMonth), new DateFormatter());
     }
 
     /**
@@ -866,14 +893,14 @@ public abstract class DateMatchers {
      *
      * @param year the year against which the examined date is checked
      * @param month the month against which the examined date is checked
-     * @param day the day of the month against which the examined date is checked
+     * @param dayOfMonth the day of the month against which the examined date is checked
      * @param hour the hour of the day against which the examined date is checked
      * @param minute the minute of the hour against which the examined date is checked
      * @param second the second of the minute against which the examined date is checked
      * @deprecated Use {@link #sameOrAfter(int, Month, int, int, int, int)}
      */
     @Deprecated
-    public static Matcher<Date> sameOrAfter(final int year,
+    public static DateMatcher<Date> sameOrAfter(final int year,
             final Months month,
             final int dayOfMonth,
             final int hour,
@@ -894,20 +921,20 @@ public abstract class DateMatchers {
      *
      * @param year the year against which the examined date is checked
      * @param month the month against which the examined date is checked
-     * @param day the day of the month against which the examined date is checked
+     * @param dayOfMonth the day of the month against which the examined date is checked
      * @param hour the hour of the day against which the examined date is checked
      * @param minute the minute of the hour against which the examined date is checked
      * @param second the second of the minute against which the examined date is checked
      */
 
-    public static Matcher<Date> sameOrAfter(final int year,
+    public static DateMatcher<Date> sameOrAfter(final int year,
             final Month month,
             final int dayOfMonth,
             final int hour,
             final int minute,
             final int second) {
-        return new IsSameOrAfter<Date>(new DateWrapper(year, month, dayOfMonth, hour, minute, second),
-                new DateFormatter());
+        return new IsSameOrAfter<>(new DateWrapper(year, month, dayOfMonth, hour, minute, second),
+            new DateFormatter());
     }
 
     /**
@@ -923,7 +950,7 @@ public abstract class DateMatchers {
      * @deprecated Use {@link #sameMinuteOfHour(Date)} instead
      */
     @Deprecated
-    public static Matcher<Date> sameMinute(final Date date) {
+    public static DateMatcher<Date> sameMinute(final Date date) {
         return sameMinuteOfHour(date);
     }
 
@@ -938,8 +965,11 @@ public abstract class DateMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<Date> sameMinuteOfHour(final Date date) {
-        return isMinute(extractField(date, ChronoField.MINUTE_OF_HOUR));
+    public static DateMatcher<Date> sameMinuteOfHour(final Date date) {
+        return new IsMinute<>(
+            new FieldDateWrapper(date, ChronoField.MINUTE_OF_HOUR),
+            (d, z) -> d.toInstant().atZone(z).get(ChronoField.MINUTE_OF_HOUR)
+        );
     }
 
     /**
@@ -955,7 +985,7 @@ public abstract class DateMatchers {
      * @deprecated Use {@link #isMinute(int)} instead
      */
     @Deprecated
-    public static Matcher<Date> sameMinute(final int minute) {
+    public static DateMatcher<Date> sameMinute(final int minute) {
         return isMinute(minute);
     }
 
@@ -970,8 +1000,11 @@ public abstract class DateMatchers {
      *
      * @param minute the reference minute against which the examined date is checked
      */
-    public static Matcher<Date> isMinute(final int minute) {
-        return new IsMinute<Date>(minute, DateMatchers::dateToZoneDateTime);
+    public static DateMatcher<Date> isMinute(final int minute) {
+        return new IsMinute<>(
+            new FieldDateWrapper(minute, ChronoField.MINUTE_OF_HOUR),
+            (d, z) -> d.toInstant().atZone(z).get(ChronoField.MINUTE_OF_HOUR)
+        );
     }
 
     /**
@@ -987,7 +1020,7 @@ public abstract class DateMatchers {
      * @deprecated Use {@link #sameMonthOfYear(Date)} instead
      */
     @Deprecated
-    public static Matcher<Date> sameMonth(final Date date) {
+    public static DateMatcher<Date> sameMonth(final Date date) {
         return sameMonthOfYear(date);
     }
 
@@ -1002,7 +1035,7 @@ public abstract class DateMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<Date> sameMonthOfYear(final Date date) {
+    public static DateMatcher<Date> sameMonthOfYear(final Date date) {
         return isMonth(Month.of(date.toInstant().atZone(ZoneId.systemDefault()).get(ChronoField.MONTH_OF_YEAR)));
     }
 
@@ -1019,7 +1052,7 @@ public abstract class DateMatchers {
      * @deprecated Use {@link #sameMonthOfYear(Months)} instead
      */
     @Deprecated
-    public static Matcher<Date> sameMonth(final Months month) {
+    public static DateMatcher<Date> sameMonth(final Months month) {
         return sameMonthOfYear(month);
     }
 
@@ -1036,7 +1069,7 @@ public abstract class DateMatchers {
      * @deprecated Use {@link #isMonth(Month)}
      */
     @Deprecated
-    public static Matcher<Date> sameMonthOfYear(final Months month) {
+    public static DateMatcher<Date> sameMonthOfYear(final Months month) {
         return isMonth(month.month());
     }
 
@@ -1053,7 +1086,7 @@ public abstract class DateMatchers {
      * @deprecated Use {@link #sameSecondOfMinute(Date)} instead
      */
     @Deprecated
-    public static Matcher<Date> sameSecond(final Date date) {
+    public static DateMatcher<Date> sameSecond(final Date date) {
         return sameSecondOfMinute(date);
     }
 
@@ -1068,8 +1101,11 @@ public abstract class DateMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<Date> sameSecondOfMinute(final Date date) {
-        return isSecond(extractField(date, ChronoField.SECOND_OF_MINUTE));
+    public static DateMatcher<Date> sameSecondOfMinute(final Date date) {
+        return new IsSecond<>(
+            new FieldDateWrapper(date, ChronoField.SECOND_OF_MINUTE),
+            (d, z) -> d.toInstant().atZone(z).get(ChronoField.SECOND_OF_MINUTE)
+        );
     }
 
     /**
@@ -1085,7 +1121,7 @@ public abstract class DateMatchers {
      * @deprecated Use {@link #isSecond(int)} instead
      */
     @Deprecated
-    public static Matcher<Date> sameSecond(final int second) {
+    public static DateMatcher<Date> sameSecond(final int second) {
         return isSecond(second);
     }
 
@@ -1100,8 +1136,11 @@ public abstract class DateMatchers {
      *
      * @param second the reference date against which the examined date is checked
      */
-    public static Matcher<Date> isSecond(final int second) {
-        return new IsSecond<Date>(second, DateMatchers::dateToZoneDateTime);
+    public static DateMatcher<Date> isSecond(final int second) {
+        return new IsSecond<>(
+            new FieldDateWrapper(second, ChronoField.SECOND_OF_MINUTE),
+            (d, z) -> d.toInstant().atZone(z).get(ChronoField.SECOND_OF_MINUTE)
+        );
     }
 
     /**
@@ -1117,7 +1156,7 @@ public abstract class DateMatchers {
      * @deprecated Use {@link #sameMillisecondOfSecond(Date)} instead
      */
     @Deprecated
-    public static Matcher<Date> sameMillisecond(final Date date) {
+    public static DateMatcher<Date> sameMillisecond(final Date date) {
         return sameMillisecondOfSecond(date);
     }
 
@@ -1132,8 +1171,11 @@ public abstract class DateMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<Date> sameMillisecondOfSecond(final Date date) {
-        return isMillisecond(extractField(date, ChronoField.MILLI_OF_SECOND));
+    public static DateMatcher<Date> sameMillisecondOfSecond(final Date date) {
+        return new IsMillisecond<>(
+            new FieldDateWrapper(date, ChronoField.MILLI_OF_SECOND),
+            (d, z) -> d.toInstant().atZone(z).get(ChronoField.MILLI_OF_SECOND)
+        );
     }
 
     /**
@@ -1149,7 +1191,7 @@ public abstract class DateMatchers {
      * @deprecated Use {@link #isMillisecond(int)} instead
      */
     @Deprecated
-    public static Matcher<Date> sameMillisecond(final int millisecond) {
+    public static DateMatcher<Date> sameMillisecond(final int millisecond) {
         return isMillisecond(millisecond);
     }
 
@@ -1164,8 +1206,11 @@ public abstract class DateMatchers {
      *
      * @param millisecond the millisecond against which the examined date is checked
      */
-    public static Matcher<Date> isMillisecond(final int millisecond) {
-        return new IsMillisecond<Date>(millisecond, DateMatchers::dateToZoneDateTime);
+    public static DateMatcher<Date> isMillisecond(final int millisecond) {
+        return new IsMillisecond<>(
+            new FieldDateWrapper(millisecond, ChronoField.MILLI_OF_SECOND),
+            (d, z) -> d.toInstant().atZone(z).get(ChronoField.MILLI_OF_SECOND)
+        );
     }
 
     /**
@@ -1179,8 +1224,11 @@ public abstract class DateMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<Date> sameYear(final Date date) {
-        return isYear(extractField(date, ChronoField.YEAR));
+    public static DateMatcher<Date> sameYear(final Date date) {
+        return new IsYear<>(
+            new FieldDateWrapper(date, ChronoField.YEAR),
+            (d, z) -> d.toInstant().atZone(z).get(ChronoField.YEAR)
+        );
     }
 
     /**
@@ -1194,8 +1242,11 @@ public abstract class DateMatchers {
      *
      * @param year the reference year against which the examined date is checked
      */
-    public static Matcher<Date> isYear(final int year) {
-        return new IsYear<Date>(year, DateMatchers::dateToZoneDateTime);
+    public static DateMatcher<Date> isYear(final int year) {
+        return new IsYear<>(
+            new FieldDateWrapper(year, ChronoField.YEAR),
+            (d, z) -> d.toInstant().atZone(z).get(ChronoField.YEAR)
+        );
     }
 
     /**
@@ -1211,7 +1262,7 @@ public abstract class DateMatchers {
      * @deprecated Use {@link #within(long, ChronoUnit, Date)}
      */
     @Deprecated
-    public static Matcher<Date> within(final long period, final TimeUnit unit, final Date date) {
+    public static DateMatcher<Date> within(final long period, final TimeUnit unit, final Date date) {
         return within(period, convertUnit(unit), date);
     }
 
@@ -1226,8 +1277,8 @@ public abstract class DateMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<Date> within(final long period, final ChronoUnit unit, final Date date) {
-        return new IsWithin<Date>(period, unit, new DateWrapper(date), new DateFormatter());
+    public static DateMatcher<Date> within(final long period, final ChronoUnit unit, final Date date) {
+        return new IsWithin<>(period, unit, new DateWrapper(date), new DateFormatter());
     }
 
     /**
@@ -1241,8 +1292,8 @@ public abstract class DateMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<Date> within(final long period, final ChronoUnit unit, final LocalDate date) {
-        return new IsWithin<Date>(period, unit, new DateWrapper(date), new DateFormatter());
+    public static DateMatcher<Date> within(final long period, final ChronoUnit unit, final LocalDate date) {
+        return new IsWithin<>(period, unit, new DateWrapper(date), new DateFormatter());
     }
 
     /**
@@ -1258,7 +1309,7 @@ public abstract class DateMatchers {
      * @deprecated Use {@link #within(long, ChronoUnit, LocalDate)}
      */
     @Deprecated
-    public static Matcher<Date> within(final long period, final TimeUnit unit, final DayMonthYear date) {
+    public static DateMatcher<Date> within(final long period, final TimeUnit unit, final DayMonthYear date) {
         return within(period, convertUnit(unit), date.toLocalDate());
     }
 
@@ -1279,7 +1330,7 @@ public abstract class DateMatchers {
      * @deprecated Use {@link #within(long, ChronoUnit, int, Month, int)}
      */
     @Deprecated
-    public static Matcher<Date> within(final long period,
+    public static DateMatcher<Date> within(final long period,
             final TimeUnit unit,
             final int year,
             final Months month,
@@ -1302,7 +1353,7 @@ public abstract class DateMatchers {
      * @param month the month against which the examined date is checked
      * @param dayOfMonth the day of the month against which the examined date is checked
      */
-    public static Matcher<Date> within(final long period,
+    public static DateMatcher<Date> within(final long period,
             final ChronoUnit unit,
             final int year,
             final Month month,
@@ -1323,15 +1374,15 @@ public abstract class DateMatchers {
      * @param unit the timeunit to define the length of the period
      * @param year the year against which the examined date is checked
      * @param month the month against which the examined date is checked
-     * @param day the day of the month against which the examined date is checked
+     * @param dayOfMonth the day of the month against which the examined date is checked
      * @param hour the hour of the day against which the examined date is checked
      * @param minute the minute of the hour against which the examined date is checked
      * @param second the second of the minute against which the examined date is checked
-     * @param second the millisecond of the second against which the examined date is checked
+     * @param milliseconds the millisecond of the second against which the examined date is checked
      * @deprecated Use {@link #within(long, ChronoUnit, int, Month, int, int, int, int, int)}
      */
     @Deprecated
-    public static Matcher<Date> within(final long period,
+    public static DateMatcher<Date> within(final long period,
             final TimeUnit unit,
             final int year,
             final Months month,
@@ -1356,13 +1407,13 @@ public abstract class DateMatchers {
      * @param unit the timeunit to define the length of the period
      * @param year the year against which the examined date is checked
      * @param month the month against which the examined date is checked
-     * @param day the day of the month against which the examined date is checked
+     * @param dayOfMonth the day of the month against which the examined date is checked
      * @param hour the hour of the day against which the examined date is checked
      * @param minute the minute of the hour against which the examined date is checked
      * @param second the second of the minute against which the examined date is checked
-     * @param second the millisecond of the second against which the examined date is checked
+     * @param milliseconds the millisecond of the second against which the examined date is checked
      */
-    public static Matcher<Date> within(final long period,
+    public static DateMatcher<Date> within(final long period,
             final ChronoUnit unit,
             final int year,
             final Month month,
@@ -1371,10 +1422,10 @@ public abstract class DateMatchers {
             final int minute,
             final int second,
             final int milliseconds) {
-        return new IsWithin<Date>(period,
-                unit,
-                new DateWrapper(year, month, dayOfMonth, hour, minute, second, milliseconds),
-                new DateFormatter());
+        return new IsWithin<>(period,
+            unit,
+            new DateWrapper(year, month, dayOfMonth, hour, minute, second, milliseconds),
+            new DateFormatter());
     }
 
     /**
@@ -1386,7 +1437,7 @@ public abstract class DateMatchers {
      * assertThat(myDate, isToday());
      * </pre>
      */
-    public static Matcher<Date> isYesterday() {
+    public static DateMatcher<Date> isYesterday() {
         return sameDay(LocalDate.now().minusDays(1));
     }
 
@@ -1399,7 +1450,7 @@ public abstract class DateMatchers {
      * assertThat(myDate, isToday());
      * </pre>
      */
-    public static Matcher<Date> isToday() {
+    public static DateMatcher<Date> isToday() {
         return sameDay(LocalDate.now());
     }
 
@@ -1412,7 +1463,7 @@ public abstract class DateMatchers {
      * assertThat(myDate, isTomorrow());
      * </pre>
      */
-    public static Matcher<Date> isTomorrow() {
+    public static DateMatcher<Date> isTomorrow() {
         return sameDay(LocalDate.now().plusDays(1));
     }
 
@@ -1425,8 +1476,8 @@ public abstract class DateMatchers {
      * assertThat(myDate, isMonday());
      * </pre>
      */
-    public static Matcher<Date> isMonday() {
-        return new IsDayOfWeek<Date>(DayOfWeek.MONDAY, DateMatchers::dateToZoneDateTime);
+    public static DateMatcher<Date> isMonday() {
+        return isDayOfWeek(DayOfWeek.MONDAY);
     }
 
     /**
@@ -1438,8 +1489,8 @@ public abstract class DateMatchers {
      * assertThat(myDate, isTuesday());
      * </pre>
      */
-    public static Matcher<Date> isTuesday() {
-        return new IsDayOfWeek<Date>(DayOfWeek.TUESDAY, DateMatchers::dateToZoneDateTime);
+    public static DateMatcher<Date> isTuesday() {
+        return isDayOfWeek(DayOfWeek.TUESDAY);
     }
 
     /**
@@ -1451,8 +1502,8 @@ public abstract class DateMatchers {
      * assertThat(myDate, isWednesday());
      * </pre>
      */
-    public static Matcher<Date> isWednesday() {
-        return new IsDayOfWeek<Date>(DayOfWeek.WEDNESDAY, DateMatchers::dateToZoneDateTime);
+    public static DateMatcher<Date> isWednesday() {
+        return isDayOfWeek(DayOfWeek.WEDNESDAY);
     }
 
     /**
@@ -1464,8 +1515,8 @@ public abstract class DateMatchers {
      * assertThat(myDate, isThursday());
      * </pre>
      */
-    public static Matcher<Date> isThursday() {
-        return new IsDayOfWeek<Date>(DayOfWeek.THURSDAY, DateMatchers::dateToZoneDateTime);
+    public static DateMatcher<Date> isThursday() {
+        return isDayOfWeek(DayOfWeek.THURSDAY);
     }
 
     /**
@@ -1477,8 +1528,8 @@ public abstract class DateMatchers {
      * assertThat(myDate, isFriday());
      * </pre>
      */
-    public static Matcher<Date> isFriday() {
-        return new IsDayOfWeek<Date>(DayOfWeek.FRIDAY, DateMatchers::dateToZoneDateTime);
+    public static DateMatcher<Date> isFriday() {
+        return isDayOfWeek(DayOfWeek.FRIDAY);
     }
 
     /**
@@ -1490,8 +1541,8 @@ public abstract class DateMatchers {
      * assertThat(myDate, isSaturday());
      * </pre>
      */
-    public static Matcher<Date> isSaturday() {
-        return new IsDayOfWeek<Date>(DayOfWeek.SATURDAY, DateMatchers::dateToZoneDateTime);
+    public static DateMatcher<Date> isSaturday() {
+        return isDayOfWeek(DayOfWeek.SATURDAY);
     }
 
     /**
@@ -1503,8 +1554,8 @@ public abstract class DateMatchers {
      * assertThat(myDate, isSunday());
      * </pre>
      */
-    public static Matcher<Date> isSunday() {
-        return new IsDayOfWeek<Date>(DayOfWeek.SUNDAY, DateMatchers::dateToZoneDateTime);
+    public static DateMatcher<Date> isSunday() {
+        return isDayOfWeek(DayOfWeek.SUNDAY);
     }
 
     /**
@@ -1516,7 +1567,7 @@ public abstract class DateMatchers {
      * assertThat(myDate, isWeekday());
      * </pre>
      */
-    public static Matcher<Date> isWeekday() {
+    public static DateMatcher<Date> isWeekday() {
         return isDayOfWeek(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY);
     }
 
@@ -1529,7 +1580,7 @@ public abstract class DateMatchers {
      * assertThat(myDate, isWeekend());
      * </pre>
      */
-    public static Matcher<Date> isWeekend() {
+    public static DateMatcher<Date> isWeekend() {
         return isDayOfWeek(SATURDAY, SUNDAY);
     }
 
@@ -1542,10 +1593,14 @@ public abstract class DateMatchers {
      * assertThat(myDate, isFirstDayOfMonth());
      * </pre>
      */
-    public static Matcher<Date> isFirstDayOfMonth() {
-        return new IsMinimum<Date>(ChronoField.DAY_OF_MONTH, DateMatchers::dateToZoneDateTime,
-                new DatePartFormatter(),
-                () -> "the date is the first day of the month");
+    public static DateMatcher<Date> isFirstDayOfMonth() {
+        return new IsMinimum<>(
+            ChronoField.DAY_OF_MONTH,
+            (d, z) -> d.toInstant().atZone(z).get(ChronoField.DAY_OF_MONTH),
+            (d, z) -> ChronoField.DAY_OF_MONTH.rangeRefinedBy(d.toInstant().atZone(z)),
+            new DatePartFormatter(),
+            () -> "the date is the first day of the month"
+        );
     }
 
     /**
@@ -1560,8 +1615,13 @@ public abstract class DateMatchers {
      *
      * @param field the temporal field to check
      */
-    public static Matcher<Date> isMinimum(final ChronoField field) {
-        return new IsMinimum<Date>(field, DateMatchers::dateToZoneDateTime, new DatePartFormatter());
+    public static DateMatcher<Date> isMinimum(final ChronoField field) {
+        return new IsMinimum<>(
+            field,
+            (d, z) -> d.toInstant().atZone(z).get(field),
+            (d, z) -> field.rangeRefinedBy(d.toInstant().atZone(z)),
+            new DatePartFormatter()
+        );
     }
 
     /**
@@ -1573,10 +1633,13 @@ public abstract class DateMatchers {
      * assertThat(myDate, isFirstDayOfMonth());
      * </pre>
      */
-    public static Matcher<Date> isLastDayOfMonth() {
-        return new IsMaximum<Date>(ChronoField.DAY_OF_MONTH, DateMatchers::dateToZoneDateTime,
-                new DatePartFormatter(),
-                () -> "the date is the last day of the month");
+    public static DateMatcher<Date> isLastDayOfMonth() {
+        return new IsMaximum<>(
+            ChronoField.DAY_OF_MONTH,
+            (d, z) -> d.toInstant().atZone(z).get(ChronoField.DAY_OF_MONTH),
+            (d, z) -> ChronoField.DAY_OF_MONTH.rangeRefinedBy(d.toInstant().atZone(z)),
+            new DatePartFormatter(),
+            () -> "the date is the last day of the month");
     }
 
     /**
@@ -1591,8 +1654,13 @@ public abstract class DateMatchers {
      *
      * @param field the temporal field to check
      */
-    public static Matcher<Date> isMaximum(final ChronoField field) {
-        return new IsMaximum<Date>(field, DateMatchers::dateToZoneDateTime, new DatePartFormatter());
+    public static DateMatcher<Date> isMaximum(final ChronoField field) {
+        return new IsMaximum<>(
+            field,
+            (d, z) -> d.toInstant().atZone(z).get(field),
+            (d, z) -> field.rangeRefinedBy(d.toInstant().atZone(z)),
+            new DatePartFormatter()
+        );
     }
 
     /**
@@ -1604,8 +1672,11 @@ public abstract class DateMatchers {
      * assertThat(myDate, isMonth(Month.AUGUST));
      * </pre>
      */
-    public static Matcher<Date> isMonth(final Month month) {
-        return new IsMonth<Date>(month, DateMatchers::dateToZoneDateTime);
+    public static DateMatcher<Date> isMonth(final Month month) {
+        return new IsMonth<>(
+            new FieldDateWrapper(month.getValue(), ChronoField.MONTH_OF_YEAR),
+            (d, z) -> d.toInstant().atZone(z).get(ChronoField.MONTH_OF_YEAR)
+        );
     }
 
     /**
@@ -1617,7 +1688,7 @@ public abstract class DateMatchers {
      * assertThat(myDate, isJanuary());
      * </pre>
      */
-    public static Matcher<Date> isJanuary() {
+    public static DateMatcher<Date> isJanuary() {
         return isMonth(JANUARY);
     }
 
@@ -1630,7 +1701,7 @@ public abstract class DateMatchers {
      * assertThat(myDate, isFebruary());
      * </pre>
      */
-    public static Matcher<Date> isFebruary() {
+    public static DateMatcher<Date> isFebruary() {
         return isMonth(FEBRUARY);
     }
 
@@ -1643,7 +1714,7 @@ public abstract class DateMatchers {
      * assertThat(myDate, isMarch());
      * </pre>
      */
-    public static Matcher<Date> isMarch() {
+    public static DateMatcher<Date> isMarch() {
         return isMonth(MARCH);
     }
 
@@ -1656,7 +1727,7 @@ public abstract class DateMatchers {
      * assertThat(myDate, isApril());
      * </pre>
      */
-    public static Matcher<Date> isApril() {
+    public static DateMatcher<Date> isApril() {
         return isMonth(APRIL);
     }
 
@@ -1669,7 +1740,7 @@ public abstract class DateMatchers {
      * assertThat(myDate, isMay());
      * </pre>
      */
-    public static Matcher<Date> isMay() {
+    public static DateMatcher<Date> isMay() {
         return isMonth(MAY);
     }
 
@@ -1682,7 +1753,7 @@ public abstract class DateMatchers {
      * assertThat(myDate, isJune());
      * </pre>
      */
-    public static Matcher<Date> isJune() {
+    public static DateMatcher<Date> isJune() {
         return isMonth(JUNE);
     }
 
@@ -1695,7 +1766,7 @@ public abstract class DateMatchers {
      * assertThat(myDate, isJuly());
      * </pre>
      */
-    public static Matcher<Date> isJuly() {
+    public static DateMatcher<Date> isJuly() {
         return isMonth(JULY);
     }
 
@@ -1708,7 +1779,7 @@ public abstract class DateMatchers {
      * assertThat(myDate, isAugust());
      * </pre>
      */
-    public static Matcher<Date> isAugust() {
+    public static DateMatcher<Date> isAugust() {
         return isMonth(AUGUST);
     }
 
@@ -1721,7 +1792,7 @@ public abstract class DateMatchers {
      * assertThat(myDate, isSeptember());
      * </pre>
      */
-    public static Matcher<Date> isSeptember() {
+    public static DateMatcher<Date> isSeptember() {
         return isMonth(SEPTEMBER);
     }
 
@@ -1734,7 +1805,7 @@ public abstract class DateMatchers {
      * assertThat(myDate, isOctober());
      * </pre>
      */
-    public static Matcher<Date> isOctober() {
+    public static DateMatcher<Date> isOctober() {
         return isMonth(OCTOBER);
     }
 
@@ -1747,7 +1818,7 @@ public abstract class DateMatchers {
      * assertThat(myDate, isNovember());
      * </pre>
      */
-    public static Matcher<Date> isNovember() {
+    public static DateMatcher<Date> isNovember() {
         return isMonth(NOVEMBER);
     }
 
@@ -1760,7 +1831,7 @@ public abstract class DateMatchers {
      * assertThat(myDate, isDecember());
      * </pre>
      */
-    public static Matcher<Date> isDecember() {
+    public static DateMatcher<Date> isDecember() {
         return isMonth(DECEMBER);
     }
 
@@ -1773,8 +1844,8 @@ public abstract class DateMatchers {
      * assertThat(myDate, isLeapYear());
      * </pre>
      */
-    public static Matcher<Date> isLeapYear() {
-        return new IsLeapYear<Date>(DateMatchers::dateToZoneDateTime, new DateFormatter());
+    public static DateMatcher<Date> isLeapYear() {
+        return new IsLeapYear<>(DateMatchers::dateToZoneDateTime, new DateFormatter());
     }
 
     private static ChronoUnit convertUnit(final TimeUnit unit) {
@@ -1798,12 +1869,8 @@ public abstract class DateMatchers {
         }
     }
 
-    private static int extractField(final Date date, final ChronoField field) {
-        return dateToZoneDateTime(date).get(field);
-    }
-
-    private static Temporal dateToZoneDateTime(final Date date) {
-        return date.toInstant().atZone(systemDefault());
+    private static Temporal dateToZoneDateTime(final Date date, final ZoneId zone) {
+        return date.toInstant().atZone(zone);
     }
 
 }

--- a/src/main/java/org/exparity/hamcrest/date/LocalDateMatchers.java
+++ b/src/main/java/org/exparity/hamcrest/date/LocalDateMatchers.java
@@ -8,26 +8,14 @@ import java.time.LocalDate;
 import java.time.Month;
 import java.time.temporal.ChronoField;
 import java.time.temporal.ChronoUnit;
-import java.util.Arrays;
+import java.util.stream.Stream;
 
-import org.exparity.hamcrest.date.core.IsAfter;
-import org.exparity.hamcrest.date.core.IsBefore;
-import org.exparity.hamcrest.date.core.IsDayOfMonth;
-import org.exparity.hamcrest.date.core.IsDayOfWeek;
-import org.exparity.hamcrest.date.core.IsLeapYear;
-import org.exparity.hamcrest.date.core.IsMaximum;
-import org.exparity.hamcrest.date.core.IsMinimum;
-import org.exparity.hamcrest.date.core.IsMonth;
-import org.exparity.hamcrest.date.core.IsSameDay;
-import org.exparity.hamcrest.date.core.IsSameOrAfter;
-import org.exparity.hamcrest.date.core.IsSameOrBefore;
-import org.exparity.hamcrest.date.core.IsWithin;
-import org.exparity.hamcrest.date.core.IsYear;
+import org.exparity.hamcrest.date.core.*;
 import org.exparity.hamcrest.date.core.format.DatePartFormatter;
 import org.exparity.hamcrest.date.core.format.LocalDateFormatter;
+import org.exparity.hamcrest.date.core.wrapper.FieldLocalDateWrapper;
 import org.exparity.hamcrest.date.core.wrapper.LocalDateWrapper;
 import org.hamcrest.Factory;
-import org.hamcrest.Matcher;
 
 /**
  * Static factory for creating {@link org.hamcrest.Matcher} instances for comparing {@link LocalDate} instances
@@ -47,8 +35,8 @@ public abstract class LocalDateMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<LocalDate> after(final LocalDate date) {
-        return new IsAfter<LocalDate>(new LocalDateWrapper(date), new LocalDateFormatter());
+    public static DateMatcher<LocalDate> after(final LocalDate date) {
+        return new IsAfter<>(new LocalDateWrapper(date), new LocalDateFormatter());
     }
 
     /**
@@ -64,7 +52,7 @@ public abstract class LocalDateMatchers {
      * @param month the month against which the examined date is checked
      * @param dayOfMonth the day of the month against which the examined date is checked
      */
-    public static Matcher<LocalDate> after(final int year, final Month month, final int dayOfMonth) {
+    public static DateMatcher<LocalDate> after(final int year, final Month month, final int dayOfMonth) {
         return after(LocalDate.of(year, month, dayOfMonth));
     }
 
@@ -79,8 +67,8 @@ public abstract class LocalDateMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<LocalDate> before(final LocalDate date) {
-        return new IsBefore<LocalDate>(new LocalDateWrapper(date), new LocalDateFormatter());
+    public static DateMatcher<LocalDate> before(final LocalDate date) {
+        return new IsBefore<>(new LocalDateWrapper(date), new LocalDateFormatter());
     }
 
     /**
@@ -96,7 +84,7 @@ public abstract class LocalDateMatchers {
      * @param month the month against which the examined date is checked
      * @param dayOfMonth the day of the month against which the examined date is checked
      */
-    public static Matcher<LocalDate> before(final int year, final Month month, final int dayOfMonth) {
+    public static DateMatcher<LocalDate> before(final int year, final Month month, final int dayOfMonth) {
         return before(LocalDate.of(year, month, dayOfMonth));
     }
 
@@ -111,8 +99,8 @@ public abstract class LocalDateMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<LocalDate> sameDay(final LocalDate date) {
-        return new IsSameDay<LocalDate>(new LocalDateWrapper(date), new LocalDateFormatter());
+    public static DateMatcher<LocalDate> sameDay(final LocalDate date) {
+        return new IsSameDay<>(new LocalDateWrapper(date), new LocalDateFormatter());
     }
 
     /**
@@ -128,7 +116,7 @@ public abstract class LocalDateMatchers {
      * @param month the reference month against which the examined date is checked
      * @param year the reference year against which the examined date is checked
      */
-    public static Matcher<LocalDate> isDay(final int year, final Month month, final int dayOfMonth) {
+    public static DateMatcher<LocalDate> isDay(final int year, final Month month, final int dayOfMonth) {
         return sameDay(LocalDate.of(year, month, dayOfMonth));
     }
 
@@ -143,8 +131,8 @@ public abstract class LocalDateMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<LocalDate> sameOrBefore(final LocalDate date) {
-        return new IsSameOrBefore<LocalDate>(new LocalDateWrapper(date), new LocalDateFormatter());
+    public static DateMatcher<LocalDate> sameOrBefore(final LocalDate date) {
+        return new IsSameOrBefore<>(new LocalDateWrapper(date), new LocalDateFormatter());
     }
 
     /**
@@ -162,7 +150,7 @@ public abstract class LocalDateMatchers {
      * @param day the day of the month against which the examined date is checked
      */
     @Factory
-    public static Matcher<LocalDate> sameOrBefore(final int year, final Month month, final int day) {
+    public static DateMatcher<LocalDate> sameOrBefore(final int year, final Month month, final int day) {
         return sameOrBefore(LocalDate.of(year, month, day));
     }
 
@@ -177,8 +165,8 @@ public abstract class LocalDateMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<LocalDate> sameOrAfter(final LocalDate date) {
-        return new IsSameOrAfter<LocalDate>(new LocalDateWrapper(date), new LocalDateFormatter());
+    public static DateMatcher<LocalDate> sameOrAfter(final LocalDate date) {
+        return new IsSameOrAfter<>(new LocalDateWrapper(date), new LocalDateFormatter());
     }
 
     /**
@@ -194,7 +182,7 @@ public abstract class LocalDateMatchers {
      * @param month the month against which the examined date is checked
      * @param day the day of the month against which the examined date is checked
      */
-    public static Matcher<LocalDate> sameOrAfter(final int year, final Month month, final int day) {
+    public static DateMatcher<LocalDate> sameOrAfter(final int year, final Month month, final int day) {
         return sameOrAfter(LocalDate.of(year, month, day));
     }
 
@@ -209,7 +197,7 @@ public abstract class LocalDateMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<LocalDate> sameMonthOfYear(final LocalDate date) {
+    public static DateMatcher<LocalDate> sameMonthOfYear(final LocalDate date) {
         return isMonth(date.getMonth());
     }
 
@@ -224,8 +212,11 @@ public abstract class LocalDateMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<LocalDate> sameDayOfMonth(final LocalDate date) {
-        return isDayOfMonth(date.getDayOfMonth());
+    public static DateMatcher<LocalDate> sameDayOfMonth(final LocalDate date) {
+        return new IsDayOfMonth<>(
+            new FieldLocalDateWrapper(date, ChronoField.DAY_OF_MONTH),
+            (d, z) -> d.atStartOfDay(z).getDayOfMonth()
+        );
     }
 
     /**
@@ -237,10 +228,13 @@ public abstract class LocalDateMatchers {
      * assertThat(myDate, isDayOfMonth(4))
      * </pre>
      *
-     * @param date the expected day of the month
+     * @param dayOfMonth the expected day of the month
      */
-    public static Matcher<LocalDate> isDayOfMonth(final int dayOfMonth) {
-        return new IsDayOfMonth<LocalDate>(dayOfMonth, t -> t);
+    public static DateMatcher<LocalDate> isDayOfMonth(final int dayOfMonth) {
+        return new IsDayOfMonth<>(
+            new FieldLocalDateWrapper(dayOfMonth, ChronoField.DAY_OF_MONTH),
+            (d, z) -> d.atStartOfDay(z).getDayOfMonth()
+        );
     }
 
     /**
@@ -254,8 +248,11 @@ public abstract class LocalDateMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<LocalDate> sameYear(final LocalDate date) {
-        return isYear(date.getYear());
+    public static DateMatcher<LocalDate> sameYear(final LocalDate date) {
+        return new IsYear<>(
+            new FieldLocalDateWrapper(date, ChronoField.YEAR),
+            (d, z) -> d.atStartOfDay(z).getYear()
+        );
     }
 
     /**
@@ -269,8 +266,11 @@ public abstract class LocalDateMatchers {
      *
      * @param year the reference year against which the examined date is checked
      */
-    public static Matcher<LocalDate> isYear(final int year) {
-        return new IsYear<LocalDate>(year, t -> t);
+    public static DateMatcher<LocalDate> isYear(final int year) {
+        return new IsYear<>(
+            new FieldLocalDateWrapper(year, ChronoField.YEAR),
+            (d, z) -> d.atStartOfDay(z).getYear()
+        );
     }
 
     /**
@@ -284,8 +284,8 @@ public abstract class LocalDateMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<LocalDate> within(final long period, final ChronoUnit unit, final LocalDate date) {
-        return new IsWithin<LocalDate>(period, unit, new LocalDateWrapper(date), new LocalDateFormatter());
+    public static DateMatcher<LocalDate> within(final long period, final ChronoUnit unit, final LocalDate date) {
+        return new IsWithin<>(period, unit, new LocalDateWrapper(date), new LocalDateFormatter());
     }
 
     /**
@@ -303,7 +303,7 @@ public abstract class LocalDateMatchers {
      * @param month the month against which the examined date is checked
      * @param dayofMonth the day of the month against which the examined date is checked
      */
-    public static Matcher<LocalDate> within(final long period,
+    public static DateMatcher<LocalDate> within(final long period,
             final ChronoUnit unit,
             final int year,
             final Month month,
@@ -320,7 +320,7 @@ public abstract class LocalDateMatchers {
      * assertThat(myDate, isToday());
      * </pre>
      */
-    public static Matcher<LocalDate> isYesterday() {
+    public static DateMatcher<LocalDate> isYesterday() {
         return sameDay(LocalDate.now().plusDays(-1));
     }
 
@@ -333,7 +333,7 @@ public abstract class LocalDateMatchers {
      * assertThat(myDate, isToday());
      * </pre>
      */
-    public static Matcher<LocalDate> isToday() {
+    public static DateMatcher<LocalDate> isToday() {
         return sameDay(LocalDate.now());
     }
 
@@ -346,7 +346,7 @@ public abstract class LocalDateMatchers {
      * assertThat(myDate, isTomorrow());
      * </pre>
      */
-    public static Matcher<LocalDate> isTomorrow() {
+    public static DateMatcher<LocalDate> isTomorrow() {
         return sameDay(LocalDate.now().plusDays(1));
     }
 
@@ -361,7 +361,7 @@ public abstract class LocalDateMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<LocalDate> sameDayOfWeek(final LocalDate date) {
+    public static DateMatcher<LocalDate> sameDayOfWeek(final LocalDate date) {
         return isDayOfWeek(DayOfWeek.from(date));
     }
 
@@ -374,8 +374,11 @@ public abstract class LocalDateMatchers {
      * assertThat(myDate, isMonday());
      * </pre>
      */
-    public static Matcher<LocalDate> isDayOfWeek(final DayOfWeek... dayOfWeek) {
-        return new IsDayOfWeek<LocalDate>(Arrays.asList(dayOfWeek), t -> t);
+    public static DateMatcher<LocalDate> isDayOfWeek(final DayOfWeek dayOfWeek) {
+        return new IsDayOfWeek<>(
+            new FieldLocalDateWrapper(dayOfWeek.getValue(), ChronoField.DAY_OF_WEEK),
+            (d, z) -> d.atStartOfDay(z).getDayOfWeek().getValue()
+        );
     }
 
     /**
@@ -387,7 +390,23 @@ public abstract class LocalDateMatchers {
      * assertThat(myDate, isMonday());
      * </pre>
      */
-    public static Matcher<LocalDate> isMonday() {
+    public static DateMatcher<LocalDate> isDayOfWeek(final DayOfWeek... daysOfWeek) {
+        return new AnyOf<>(
+            Stream.of(daysOfWeek).map(LocalDateMatchers::isDayOfWeek),
+            (d, z) -> "the date is on a " + d.atStartOfDay(z).getDayOfWeek().name().toLowerCase()
+        );
+    }
+
+    /**
+     * Creates a matcher that matches when the examined date is on a monday
+     * <p/>
+     * For example:
+     *
+     * <pre>
+     * assertThat(myDate, isMonday());
+     * </pre>
+     */
+    public static DateMatcher<LocalDate> isMonday() {
         return isDayOfWeek(MONDAY);
     }
 
@@ -400,7 +419,7 @@ public abstract class LocalDateMatchers {
      * assertThat(myDate, isTuesday());
      * </pre>
      */
-    public static Matcher<LocalDate> isTuesday() {
+    public static DateMatcher<LocalDate> isTuesday() {
         return isDayOfWeek(TUESDAY);
     }
 
@@ -413,7 +432,7 @@ public abstract class LocalDateMatchers {
      * assertThat(myDate, isWednesday());
      * </pre>
      */
-    public static Matcher<LocalDate> isWednesday() {
+    public static DateMatcher<LocalDate> isWednesday() {
         return isDayOfWeek(WEDNESDAY);
     }
 
@@ -426,7 +445,7 @@ public abstract class LocalDateMatchers {
      * assertThat(myDate, isThursday());
      * </pre>
      */
-    public static Matcher<LocalDate> isThursday() {
+    public static DateMatcher<LocalDate> isThursday() {
         return isDayOfWeek(THURSDAY);
     }
 
@@ -439,7 +458,7 @@ public abstract class LocalDateMatchers {
      * assertThat(myDate, isFriday());
      * </pre>
      */
-    public static Matcher<LocalDate> isFriday() {
+    public static DateMatcher<LocalDate> isFriday() {
         return isDayOfWeek(FRIDAY);
     }
 
@@ -452,7 +471,7 @@ public abstract class LocalDateMatchers {
      * assertThat(myDate, isSaturday());
      * </pre>
      */
-    public static Matcher<LocalDate> isSaturday() {
+    public static DateMatcher<LocalDate> isSaturday() {
         return isDayOfWeek(SATURDAY);
     }
 
@@ -465,7 +484,7 @@ public abstract class LocalDateMatchers {
      * assertThat(myDate, isSunday());
      * </pre>
      */
-    public static Matcher<LocalDate> isSunday() {
+    public static DateMatcher<LocalDate> isSunday() {
         return isDayOfWeek(SUNDAY);
     }
 
@@ -478,7 +497,7 @@ public abstract class LocalDateMatchers {
      * assertThat(myDate, isWeekday());
      * </pre>
      */
-    public static Matcher<LocalDate> isWeekday() {
+    public static DateMatcher<LocalDate> isWeekday() {
         return isDayOfWeek(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY);
     }
 
@@ -491,7 +510,7 @@ public abstract class LocalDateMatchers {
      * assertThat(myDate, isWeekend());
      * </pre>
      */
-    public static Matcher<LocalDate> isWeekend() {
+    public static DateMatcher<LocalDate> isWeekend() {
         return isDayOfWeek(SATURDAY, SUNDAY);
     }
 
@@ -504,10 +523,14 @@ public abstract class LocalDateMatchers {
      * assertThat(myDate, isFirstDayOfMonth());
      * </pre>
      */
-    public static Matcher<LocalDate> isFirstDayOfMonth() {
-        return new IsMinimum<LocalDate>(ChronoField.DAY_OF_MONTH, t -> t,
-                new DatePartFormatter(),
-                () -> "the date is the first day of the month");
+    public static DateMatcher<LocalDate> isFirstDayOfMonth() {
+        return new IsMinimum<>(
+            ChronoField.DAY_OF_MONTH,
+            (d, z) -> d.atStartOfDay(z).get(ChronoField.DAY_OF_MONTH),
+            (d, z) -> ChronoField.DAY_OF_MONTH.rangeRefinedBy(d.atStartOfDay(z)),
+            new DatePartFormatter(),
+            () -> "the date is the first day of the month"
+        );
     }
 
     /**
@@ -522,8 +545,13 @@ public abstract class LocalDateMatchers {
      *
      * @param field the temporal field to check
      */
-    public static Matcher<LocalDate> isMinimum(final ChronoField field) {
-        return new IsMinimum<LocalDate>(field, t -> t, new DatePartFormatter());
+    public static DateMatcher<LocalDate> isMinimum(final ChronoField field) {
+        return new IsMinimum<>(
+            field,
+            (d, z) -> d.atStartOfDay(z).get(field),
+            (d, z) -> field.rangeRefinedBy(d.atStartOfDay(z)),
+            new DatePartFormatter()
+        );
     }
 
     /**
@@ -535,10 +563,14 @@ public abstract class LocalDateMatchers {
      * assertThat(myDate, isFirstDayOfMonth());
      * </pre>
      */
-    public static Matcher<LocalDate> isLastDayOfMonth() {
-        return new IsMaximum<LocalDate>(ChronoField.DAY_OF_MONTH, t -> t,
-                new DatePartFormatter(),
-                () -> "the date is the last day of the month");
+    public static DateMatcher<LocalDate> isLastDayOfMonth() {
+        return new IsMaximum<>(
+            ChronoField.DAY_OF_MONTH,
+            (d, z) -> d.atStartOfDay(z).get(ChronoField.DAY_OF_MONTH),
+            (d, z) -> ChronoField.DAY_OF_MONTH.rangeRefinedBy(d.atStartOfDay(z)),
+            new DatePartFormatter(),
+            () -> "the date is the last day of the month"
+        );
     }
 
     /**
@@ -553,8 +585,13 @@ public abstract class LocalDateMatchers {
      *
      * @param field the temporal field to check
      */
-    public static Matcher<LocalDate> isMaximum(final ChronoField field) {
-        return new IsMaximum<LocalDate>(field, t -> t, new DatePartFormatter());
+    public static DateMatcher<LocalDate> isMaximum(final ChronoField field) {
+        return new IsMaximum<>(
+            field,
+            (d, z) -> d.atStartOfDay(z).get(field),
+            (d, z) -> field.rangeRefinedBy(d.atStartOfDay(z)),
+            new DatePartFormatter()
+        );
     }
 
     /**
@@ -566,8 +603,11 @@ public abstract class LocalDateMatchers {
      * assertThat(myDate, isMonth(Month.AUGUST));
      * </pre>
      */
-    public static Matcher<LocalDate> isMonth(final Month month) {
-        return new IsMonth<LocalDate>(month, t -> t);
+    public static DateMatcher<LocalDate> isMonth(final Month month) {
+        return new IsMonth<>(
+            new FieldLocalDateWrapper(month.getValue(), ChronoField.MONTH_OF_YEAR),
+            (d, z) -> d.atStartOfDay(z).getMonthValue()
+        );
     }
 
     /**
@@ -579,7 +619,7 @@ public abstract class LocalDateMatchers {
      * assertThat(myDate, isJanuary());
      * </pre>
      */
-    public static Matcher<LocalDate> isJanuary() {
+    public static DateMatcher<LocalDate> isJanuary() {
         return isMonth(JANUARY);
     }
 
@@ -592,7 +632,7 @@ public abstract class LocalDateMatchers {
      * assertThat(myDate, isFebruary());
      * </pre>
      */
-    public static Matcher<LocalDate> isFebruary() {
+    public static DateMatcher<LocalDate> isFebruary() {
         return isMonth(FEBRUARY);
     }
 
@@ -605,7 +645,7 @@ public abstract class LocalDateMatchers {
      * assertThat(myDate, isMarch());
      * </pre>
      */
-    public static Matcher<LocalDate> isMarch() {
+    public static DateMatcher<LocalDate> isMarch() {
         return isMonth(MARCH);
     }
 
@@ -618,7 +658,7 @@ public abstract class LocalDateMatchers {
      * assertThat(myDate, isApril());
      * </pre>
      */
-    public static Matcher<LocalDate> isApril() {
+    public static DateMatcher<LocalDate> isApril() {
         return isMonth(APRIL);
     }
 
@@ -631,7 +671,7 @@ public abstract class LocalDateMatchers {
      * assertThat(myDate, isMay());
      * </pre>
      */
-    public static Matcher<LocalDate> isMay() {
+    public static DateMatcher<LocalDate> isMay() {
         return isMonth(MAY);
     }
 
@@ -644,7 +684,7 @@ public abstract class LocalDateMatchers {
      * assertThat(myDate, isJune());
      * </pre>
      */
-    public static Matcher<LocalDate> isJune() {
+    public static DateMatcher<LocalDate> isJune() {
         return isMonth(JUNE);
     }
 
@@ -657,7 +697,7 @@ public abstract class LocalDateMatchers {
      * assertThat(myDate, isJuly());
      * </pre>
      */
-    public static Matcher<LocalDate> isJuly() {
+    public static DateMatcher<LocalDate> isJuly() {
         return isMonth(JULY);
     }
 
@@ -670,7 +710,7 @@ public abstract class LocalDateMatchers {
      * assertThat(myDate, isAugust());
      * </pre>
      */
-    public static Matcher<LocalDate> isAugust() {
+    public static DateMatcher<LocalDate> isAugust() {
         return isMonth(AUGUST);
     }
 
@@ -683,7 +723,7 @@ public abstract class LocalDateMatchers {
      * assertThat(myDate, isSeptember());
      * </pre>
      */
-    public static Matcher<LocalDate> isSeptember() {
+    public static DateMatcher<LocalDate> isSeptember() {
         return isMonth(SEPTEMBER);
     }
 
@@ -696,7 +736,7 @@ public abstract class LocalDateMatchers {
      * assertThat(myDate, isOctober());
      * </pre>
      */
-    public static Matcher<LocalDate> isOctober() {
+    public static DateMatcher<LocalDate> isOctober() {
         return isMonth(OCTOBER);
     }
 
@@ -709,7 +749,7 @@ public abstract class LocalDateMatchers {
      * assertThat(myDate, isNovember());
      * </pre>
      */
-    public static Matcher<LocalDate> isNovember() {
+    public static DateMatcher<LocalDate> isNovember() {
         return isMonth(NOVEMBER);
     }
 
@@ -722,7 +762,7 @@ public abstract class LocalDateMatchers {
      * assertThat(myDate, isDecember());
      * </pre>
      */
-    public static Matcher<LocalDate> isDecember() {
+    public static DateMatcher<LocalDate> isDecember() {
         return isMonth(DECEMBER);
     }
 
@@ -735,7 +775,7 @@ public abstract class LocalDateMatchers {
      * assertThat(myDate, isLeapYear());
      * </pre>
      */
-    public static Matcher<LocalDate> isLeapYear() {
-        return new IsLeapYear<LocalDate>(t -> t, new LocalDateFormatter());
+    public static DateMatcher<LocalDate> isLeapYear() {
+        return new IsLeapYear<>((d, z) -> d, new LocalDateFormatter());
     }
 }

--- a/src/main/java/org/exparity/hamcrest/date/LocalDateTimeMatchers.java
+++ b/src/main/java/org/exparity/hamcrest/date/LocalDateTimeMatchers.java
@@ -2,36 +2,18 @@ package org.exparity.hamcrest.date;
 
 import static java.time.DayOfWeek.*;
 import static java.time.Month.*;
-import static java.util.Arrays.asList;
 
-import java.time.DayOfWeek;
-import java.time.LocalDateTime;
-import java.time.Month;
+import java.time.*;
 import java.time.temporal.ChronoField;
 import java.time.temporal.ChronoUnit;
+import java.util.stream.Stream;
 
-import org.exparity.hamcrest.date.core.IsAfter;
-import org.exparity.hamcrest.date.core.IsBefore;
-import org.exparity.hamcrest.date.core.IsDayOfMonth;
-import org.exparity.hamcrest.date.core.IsDayOfWeek;
-import org.exparity.hamcrest.date.core.IsHour;
-import org.exparity.hamcrest.date.core.IsLeapYear;
-import org.exparity.hamcrest.date.core.IsMaximum;
-import org.exparity.hamcrest.date.core.IsMinimum;
-import org.exparity.hamcrest.date.core.IsMinute;
-import org.exparity.hamcrest.date.core.IsMonth;
-import org.exparity.hamcrest.date.core.IsSame;
-import org.exparity.hamcrest.date.core.IsSameDay;
-import org.exparity.hamcrest.date.core.IsSameOrAfter;
-import org.exparity.hamcrest.date.core.IsSameOrBefore;
-import org.exparity.hamcrest.date.core.IsSecond;
-import org.exparity.hamcrest.date.core.IsWithin;
-import org.exparity.hamcrest.date.core.IsYear;
+import org.exparity.hamcrest.date.core.*;
 import org.exparity.hamcrest.date.core.format.DatePartFormatter;
 import org.exparity.hamcrest.date.core.format.LocalDateTimeFormatter;
+import org.exparity.hamcrest.date.core.wrapper.FieldLocalDateTimeWrapper;
 import org.exparity.hamcrest.date.core.wrapper.LocalDateTimeWrapper;
 import org.hamcrest.Factory;
-import org.hamcrest.Matcher;
 
 /**
  * Static factory for creating {@link org.hamcrest.Matcher} instances for comparing {@link LocalDateTime} instances
@@ -51,8 +33,8 @@ public abstract class LocalDateTimeMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<LocalDateTime> after(final LocalDateTime date) {
-        return new IsAfter<LocalDateTime>(new LocalDateTimeWrapper(date), new LocalDateTimeFormatter());
+    public static DateMatcher<LocalDateTime> after(final LocalDateTime date) {
+        return new IsAfter<>(new LocalDateTimeWrapper(date), new LocalDateTimeFormatter());
     }
 
     /**
@@ -71,14 +53,14 @@ public abstract class LocalDateTimeMatchers {
      * @param minute the minute of the hour
      * @param second the second of the minute
      */
-    public static Matcher<LocalDateTime> after(final int year,
+    public static DateMatcher<LocalDateTime> after(final int year,
             final Month month,
             final int dayOfMonth,
             final int hour,
             final int minute,
             final int second) {
-        return new IsAfter<LocalDateTime>(new LocalDateTimeWrapper(year, month, dayOfMonth, hour, minute, second),
-                new LocalDateTimeFormatter());
+        return new IsAfter<>(new LocalDateTimeWrapper(year, month, dayOfMonth, hour, minute, second),
+            new LocalDateTimeFormatter());
     }
 
     /**
@@ -92,8 +74,8 @@ public abstract class LocalDateTimeMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<LocalDateTime> before(final LocalDateTime date) {
-        return new IsBefore<LocalDateTime>(new LocalDateTimeWrapper(date), new LocalDateTimeFormatter());
+    public static DateMatcher<LocalDateTime> before(final LocalDateTime date) {
+        return new IsBefore<>(new LocalDateTimeWrapper(date), new LocalDateTimeFormatter());
     }
 
     /**
@@ -112,14 +94,14 @@ public abstract class LocalDateTimeMatchers {
      * @param minute the minute of the hour
      * @param second the second of the minute
      */
-    public static Matcher<LocalDateTime> before(final int year,
+    public static DateMatcher<LocalDateTime> before(final int year,
             final Month month,
             final int dayOfMonth,
             final int hour,
             final int minute,
             final int second) {
-        return new IsBefore<LocalDateTime>(new LocalDateTimeWrapper(year, month, dayOfMonth, hour, minute, second),
-                new LocalDateTimeFormatter());
+        return new IsBefore<>(new LocalDateTimeWrapper(year, month, dayOfMonth, hour, minute, second),
+            new LocalDateTimeFormatter());
     }
 
     /**
@@ -133,8 +115,11 @@ public abstract class LocalDateTimeMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<LocalDateTime> sameDay(final LocalDateTime date) {
-        return new IsSameDay<LocalDateTime>(new LocalDateTimeWrapper(date), new LocalDateTimeFormatter());
+    public static DateMatcher<LocalDateTime> sameDay(final LocalDateTime date) {
+        return new IsSameDay<>(
+            new LocalDateTimeWrapper(date),
+            new LocalDateTimeFormatter()
+        );
     }
 
     /**
@@ -150,9 +135,11 @@ public abstract class LocalDateTimeMatchers {
      * @param month the reference month against which the examined date is checked
      * @param year the reference year against which the examined date is checked
      */
-    public static Matcher<LocalDateTime> isDay(final int year, final Month month, final int dayOfMonth) {
-        return new IsSameDay<LocalDateTime>(new LocalDateTimeWrapper(year, month, dayOfMonth),
-                new LocalDateTimeFormatter());
+    public static DateMatcher<LocalDateTime> isDay(final int year, final Month month, final int dayOfMonth) {
+        return new IsSameDay<>(
+            new LocalDateTimeWrapper(year, month, dayOfMonth),
+            new LocalDateTimeFormatter()
+        );
     }
 
     /**
@@ -166,8 +153,8 @@ public abstract class LocalDateTimeMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<LocalDateTime> sameInstant(final LocalDateTime date) {
-        return new IsSame<LocalDateTime>(new LocalDateTimeWrapper(date), new LocalDateTimeFormatter());
+    public static DateMatcher<LocalDateTime> sameInstant(final LocalDateTime date) {
+        return new IsSame<>(new LocalDateTimeWrapper(date), new LocalDateTimeFormatter());
     }
 
     /**
@@ -187,15 +174,15 @@ public abstract class LocalDateTimeMatchers {
      * @param second the second of the minute
      * @param nanos the nanosecond of the second
      */
-    public static Matcher<LocalDateTime> isInstant(final int year,
+    public static DateMatcher<LocalDateTime> isInstant(final int year,
             final Month month,
             final int dayOfMonth,
             final int hour,
             final int minute,
             final int second,
             final int nanos) {
-        return new IsSame<LocalDateTime>(new LocalDateTimeWrapper(year, month, dayOfMonth, hour, minute, second, nanos),
-                new LocalDateTimeFormatter());
+        return new IsSame<>(new LocalDateTimeWrapper(year, month, dayOfMonth, hour, minute, second, nanos),
+            new LocalDateTimeFormatter());
     }
 
     /**
@@ -209,8 +196,8 @@ public abstract class LocalDateTimeMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<LocalDateTime> sameOrBefore(final LocalDateTime date) {
-        return new IsSameOrBefore<LocalDateTime>(new LocalDateTimeWrapper(date), new LocalDateTimeFormatter());
+    public static DateMatcher<LocalDateTime> sameOrBefore(final LocalDateTime date) {
+        return new IsSameOrBefore<>(new LocalDateTimeWrapper(date), new LocalDateTimeFormatter());
     }
 
     /**
@@ -231,14 +218,14 @@ public abstract class LocalDateTimeMatchers {
      * @param second the second of the minute
      */
     @Factory
-    public static Matcher<LocalDateTime> sameOrBefore(final int year,
+    public static DateMatcher<LocalDateTime> sameOrBefore(final int year,
             final Month month,
             final int day,
             final int hour,
             final int minute,
             final int second) {
-        return new IsSameOrBefore<LocalDateTime>(new LocalDateTimeWrapper(year, month, day, hour, minute, second),
-                new LocalDateTimeFormatter());
+        return new IsSameOrBefore<>(new LocalDateTimeWrapper(year, month, day, hour, minute, second),
+            new LocalDateTimeFormatter());
     }
 
     /**
@@ -252,8 +239,8 @@ public abstract class LocalDateTimeMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<LocalDateTime> sameOrAfter(final LocalDateTime date) {
-        return new IsSameOrAfter<LocalDateTime>(new LocalDateTimeWrapper(date), new LocalDateTimeFormatter());
+    public static DateMatcher<LocalDateTime> sameOrAfter(final LocalDateTime date) {
+        return new IsSameOrAfter<>(new LocalDateTimeWrapper(date), new LocalDateTimeFormatter());
     }
 
     /**
@@ -272,7 +259,7 @@ public abstract class LocalDateTimeMatchers {
      * @param minute the minute of the hour
      * @param second the second of the minute
      */
-    public static Matcher<LocalDateTime> sameOrAfter(final int year,
+    public static DateMatcher<LocalDateTime> sameOrAfter(final int year,
             final Month month,
             final int day,
             final int hour,
@@ -292,8 +279,11 @@ public abstract class LocalDateTimeMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<LocalDateTime> sameMonthOfYear(final LocalDateTime date) {
-        return isMonth(date.getMonth());
+    public static DateMatcher<LocalDateTime> sameMonthOfYear(final LocalDateTime date) {
+        return new IsMonth<>(
+            new FieldLocalDateTimeWrapper(date, ChronoField.MONTH_OF_YEAR),
+            (d, z) -> ZonedDateTime.of(d, z).getMonthValue()
+        );
     }
 
     /**
@@ -307,8 +297,11 @@ public abstract class LocalDateTimeMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<LocalDateTime> sameDayOfMonth(final LocalDateTime date) {
-        return isDayOfMonth(date.getDayOfMonth());
+    public static DateMatcher<LocalDateTime> sameDayOfMonth(final LocalDateTime date) {
+        return new IsDayOfMonth<>(
+            new FieldLocalDateTimeWrapper(date, ChronoField.DAY_OF_MONTH),
+            (d, z) -> ZonedDateTime.of(d, z).getDayOfMonth()
+        );
     }
 
     /**
@@ -320,10 +313,13 @@ public abstract class LocalDateTimeMatchers {
      * assertThat(myDate, isDayOfMonth(4))
      * </pre>
      *
-     * @param date the expected day of the month
+     * @param dayOfMonth the expected day of the month
      */
-    public static Matcher<LocalDateTime> isDayOfMonth(final int dayOfMonth) {
-        return new IsDayOfMonth<LocalDateTime>(dayOfMonth, t -> t);
+    public static DateMatcher<LocalDateTime> isDayOfMonth(final int dayOfMonth) {
+        return new IsDayOfMonth<>(
+            new FieldLocalDateTimeWrapper(dayOfMonth, ChronoField.DAY_OF_MONTH),
+            (d, z) -> ZonedDateTime.of(d, z).getDayOfMonth()
+        );
     }
 
     /**
@@ -337,8 +333,11 @@ public abstract class LocalDateTimeMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<LocalDateTime> sameYear(final LocalDateTime date) {
-        return isYear(date.getYear());
+    public static DateMatcher<LocalDateTime> sameYear(final LocalDateTime date) {
+        return new IsYear<>(
+            new FieldLocalDateTimeWrapper(date, ChronoField.YEAR),
+            (d, z) -> ZonedDateTime.of(d ,z).getYear()
+        );
     }
 
     /**
@@ -352,8 +351,11 @@ public abstract class LocalDateTimeMatchers {
      *
      * @param year the reference year against which the examined date is checked
      */
-    public static Matcher<LocalDateTime> isYear(final int year) {
-        return new IsYear<LocalDateTime>(year, t -> t);
+    public static DateMatcher<LocalDateTime> isYear(final int year) {
+        return new IsYear<>(
+            new FieldLocalDateTimeWrapper(year, ChronoField.YEAR),
+            (d, z) -> ZonedDateTime.of(d ,z).getYear()
+        );
     }
 
     /**
@@ -367,8 +369,8 @@ public abstract class LocalDateTimeMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<LocalDateTime> within(final long period, final ChronoUnit unit, final LocalDateTime date) {
-        return new IsWithin<LocalDateTime>(period, unit, new LocalDateTimeWrapper(date), new LocalDateTimeFormatter());
+    public static DateMatcher<LocalDateTime> within(final long period, final ChronoUnit unit, final LocalDateTime date) {
+        return new IsWithin<>(period, unit, new LocalDateTimeWrapper(date), new LocalDateTimeFormatter());
     }
 
     /**
@@ -385,16 +387,12 @@ public abstract class LocalDateTimeMatchers {
      * @param year the year against which the examined date is checked
      * @param month the month against which the examined date is checked
      * @param dayofMonth the day of the month against which the examined date is checked
-     * @param hour
      * @param hour the hour of the day
      * @param minute the minute of the hour
      * @param second the second of the minute
-     * @param hour the hour of the day
-     * @param minute the minute of the hour
-     * @param second the second of the minute
-     * @param nanons the nanoseconds of the second
+     * @param nanos the nanoseconds of the second
      */
-    public static Matcher<LocalDateTime> within(final long period,
+    public static DateMatcher<LocalDateTime> within(final long period,
             final ChronoUnit unit,
             final int year,
             final Month month,
@@ -403,9 +401,9 @@ public abstract class LocalDateTimeMatchers {
             final int minute,
             final int second,
             final int nanos) {
-        return new IsWithin<LocalDateTime>(period, unit,
-                new LocalDateTimeWrapper(year, month, dayofMonth, hour, minute, second, nanos),
-                new LocalDateTimeFormatter());
+        return new IsWithin<>(period, unit,
+            new LocalDateTimeWrapper(year, month, dayofMonth, hour, minute, second, nanos),
+            new LocalDateTimeFormatter());
     }
 
     /**
@@ -417,7 +415,7 @@ public abstract class LocalDateTimeMatchers {
      * assertThat(myDate, isToday());
      * </pre>
      */
-    public static Matcher<LocalDateTime> isYesterday() {
+    public static DateMatcher<LocalDateTime> isYesterday() {
         return sameDay(LocalDateTime.now().minusDays(1));
     }
 
@@ -430,7 +428,7 @@ public abstract class LocalDateTimeMatchers {
      * assertThat(myDate, isToday());
      * </pre>
      */
-    public static Matcher<LocalDateTime> isToday() {
+    public static DateMatcher<LocalDateTime> isToday() {
         return sameDay(LocalDateTime.now());
     }
 
@@ -443,8 +441,8 @@ public abstract class LocalDateTimeMatchers {
      * assertThat(myDate, isTomorrow());
      * </pre>
      */
-    public static Matcher<LocalDateTime> isTomorrow() {
-        return sameDay(LocalDateTime.now().plusDays(1));
+    public static DateMatcher<LocalDateTime> isTomorrow() {
+        return sameDay(LocalDateTime.now(ZoneId.systemDefault()).plusDays(1));
     }
 
     /**
@@ -458,7 +456,7 @@ public abstract class LocalDateTimeMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<LocalDateTime> sameDayOfWeek(final LocalDateTime date) {
+    public static DateMatcher<LocalDateTime> sameDayOfWeek(final LocalDateTime date) {
         return isDayOfWeek(DayOfWeek.from(date));
     }
 
@@ -471,8 +469,11 @@ public abstract class LocalDateTimeMatchers {
      * assertThat(myDate, isMonday());
      * </pre>
      */
-    public static Matcher<LocalDateTime> isDayOfWeek(final DayOfWeek... dayOfWeek) {
-        return new IsDayOfWeek<LocalDateTime>(asList(dayOfWeek), t -> t);
+    public static DateMatcher<LocalDateTime> isDayOfWeek(final DayOfWeek dayOfWeek) {
+        return new IsDayOfWeek<>(
+            new FieldLocalDateTimeWrapper(dayOfWeek.getValue(), ChronoField.DAY_OF_WEEK),
+            (d, z) -> ZonedDateTime.of(d, z).getDayOfWeek().getValue()
+        );
     }
 
     /**
@@ -484,7 +485,23 @@ public abstract class LocalDateTimeMatchers {
      * assertThat(myDate, isMonday());
      * </pre>
      */
-    public static Matcher<LocalDateTime> isMonday() {
+    public static DateMatcher<LocalDateTime> isDayOfWeek(final DayOfWeek... daysOfWeek) {
+        return new AnyOf<>(
+            Stream.of(daysOfWeek).map(LocalDateTimeMatchers::isDayOfWeek),
+            (d, z) -> "the date is on a " + d.atZone(z).getDayOfWeek().name().toLowerCase()
+        );
+    }
+
+    /**
+     * Creates a matcher that matches when the examined date is on a monday
+     * <p/>
+     * For example:
+     *
+     * <pre>
+     * assertThat(myDate, isMonday());
+     * </pre>
+     */
+    public static DateMatcher<LocalDateTime> isMonday() {
         return isDayOfWeek(MONDAY);
     }
 
@@ -497,7 +514,7 @@ public abstract class LocalDateTimeMatchers {
      * assertThat(myDate, isTuesday());
      * </pre>
      */
-    public static Matcher<LocalDateTime> isTuesday() {
+    public static DateMatcher<LocalDateTime> isTuesday() {
         return isDayOfWeek(TUESDAY);
     }
 
@@ -510,7 +527,7 @@ public abstract class LocalDateTimeMatchers {
      * assertThat(myDate, isWednesday());
      * </pre>
      */
-    public static Matcher<LocalDateTime> isWednesday() {
+    public static DateMatcher<LocalDateTime> isWednesday() {
         return isDayOfWeek(WEDNESDAY);
     }
 
@@ -523,7 +540,7 @@ public abstract class LocalDateTimeMatchers {
      * assertThat(myDate, isThursday());
      * </pre>
      */
-    public static Matcher<LocalDateTime> isThursday() {
+    public static DateMatcher<LocalDateTime> isThursday() {
         return isDayOfWeek(THURSDAY);
     }
 
@@ -536,7 +553,7 @@ public abstract class LocalDateTimeMatchers {
      * assertThat(myDate, isFriday());
      * </pre>
      */
-    public static Matcher<LocalDateTime> isFriday() {
+    public static DateMatcher<LocalDateTime> isFriday() {
         return isDayOfWeek(FRIDAY);
     }
 
@@ -549,7 +566,7 @@ public abstract class LocalDateTimeMatchers {
      * assertThat(myDate, isSaturday());
      * </pre>
      */
-    public static Matcher<LocalDateTime> isSaturday() {
+    public static DateMatcher<LocalDateTime> isSaturday() {
         return isDayOfWeek(SATURDAY);
     }
 
@@ -562,7 +579,7 @@ public abstract class LocalDateTimeMatchers {
      * assertThat(myDate, isSunday());
      * </pre>
      */
-    public static Matcher<LocalDateTime> isSunday() {
+    public static DateMatcher<LocalDateTime> isSunday() {
         return isDayOfWeek(SUNDAY);
     }
 
@@ -575,7 +592,7 @@ public abstract class LocalDateTimeMatchers {
      * assertThat(myDate, isWeekday());
      * </pre>
      */
-    public static Matcher<LocalDateTime> isWeekday() {
+    public static DateMatcher<LocalDateTime> isWeekday() {
         return isDayOfWeek(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY);
     }
 
@@ -588,7 +605,7 @@ public abstract class LocalDateTimeMatchers {
      * assertThat(myDate, isWeekend());
      * </pre>
      */
-    public static Matcher<LocalDateTime> isWeekend() {
+    public static DateMatcher<LocalDateTime> isWeekend() {
         return isDayOfWeek(SATURDAY, SUNDAY);
     }
 
@@ -601,10 +618,13 @@ public abstract class LocalDateTimeMatchers {
      * assertThat(myDate, isFirstDayOfMonth());
      * </pre>
      */
-    public static Matcher<LocalDateTime> isFirstDayOfMonth() {
-        return new IsMinimum<LocalDateTime>(ChronoField.DAY_OF_MONTH, t -> t,
-                new DatePartFormatter(),
-                () -> "the date is the first day of the month");
+    public static DateMatcher<LocalDateTime> isFirstDayOfMonth() {
+        return new IsMinimum<>(
+            ChronoField.DAY_OF_MONTH,
+            (d, z) -> d.atZone(z).get(ChronoField.DAY_OF_MONTH),
+            (d, z) -> ChronoField.DAY_OF_MONTH.rangeRefinedBy(d.atZone(z)),
+            new DatePartFormatter(),
+            () -> "the date is the first day of the month");
     }
 
     /**
@@ -619,8 +639,13 @@ public abstract class LocalDateTimeMatchers {
      *
      * @param field the temporal field to check
      */
-    public static Matcher<LocalDateTime> isMinimum(final ChronoField field) {
-        return new IsMinimum<LocalDateTime>(field, t -> t, new DatePartFormatter());
+    public static DateMatcher<LocalDateTime> isMinimum(final ChronoField field) {
+        return new IsMinimum<>(
+            field,
+            (d, z) -> d.atZone(z).get(field),
+            (d, z) -> field.rangeRefinedBy(d.atZone(z)),
+            new DatePartFormatter()
+        );
     }
 
     /**
@@ -632,10 +657,13 @@ public abstract class LocalDateTimeMatchers {
      * assertThat(myDate, isFirstDayOfMonth());
      * </pre>
      */
-    public static Matcher<LocalDateTime> isLastDayOfMonth() {
-        return new IsMaximum<LocalDateTime>(ChronoField.DAY_OF_MONTH, t -> t,
-                new DatePartFormatter(),
-                () -> "the date is the last day of the month");
+    public static DateMatcher<LocalDateTime> isLastDayOfMonth() {
+        return new IsMaximum<>(
+            ChronoField.DAY_OF_MONTH,
+            (d, z) -> d.atZone(z).get(ChronoField.DAY_OF_MONTH),
+            (d, z) -> ChronoField.DAY_OF_MONTH.rangeRefinedBy(d.atZone(z)),
+            new DatePartFormatter(),
+            () -> "the date is the last day of the month");
     }
 
     /**
@@ -650,8 +678,13 @@ public abstract class LocalDateTimeMatchers {
      *
      * @param field the temporal field to check
      */
-    public static Matcher<LocalDateTime> isMaximum(final ChronoField field) {
-        return new IsMaximum<LocalDateTime>(field, t -> t, new DatePartFormatter());
+    public static DateMatcher<LocalDateTime> isMaximum(final ChronoField field) {
+        return new IsMaximum<>(
+            field,
+            (d, z) -> d.atZone(z).get(field),
+            (d, z) -> field.rangeRefinedBy(d.atZone(z)),
+            new DatePartFormatter()
+        );
     }
 
     /**
@@ -663,8 +696,11 @@ public abstract class LocalDateTimeMatchers {
      * assertThat(myDate, isMonth(Month.AUGUST));
      * </pre>
      */
-    public static Matcher<LocalDateTime> isMonth(final Month month) {
-        return new IsMonth<LocalDateTime>(month, t -> t);
+    public static DateMatcher<LocalDateTime> isMonth(final Month month) {
+        return new IsMonth<>(
+            new FieldLocalDateTimeWrapper(month.getValue(), ChronoField.MONTH_OF_YEAR),
+            (d, z) -> ZonedDateTime.of(d, z).getMonthValue()
+        );
     }
 
     /**
@@ -676,7 +712,7 @@ public abstract class LocalDateTimeMatchers {
      * assertThat(myDate, isJanuary());
      * </pre>
      */
-    public static Matcher<LocalDateTime> isJanuary() {
+    public static DateMatcher<LocalDateTime> isJanuary() {
         return isMonth(JANUARY);
     }
 
@@ -689,7 +725,7 @@ public abstract class LocalDateTimeMatchers {
      * assertThat(myDate, isFebruary());
      * </pre>
      */
-    public static Matcher<LocalDateTime> isFebruary() {
+    public static DateMatcher<LocalDateTime> isFebruary() {
         return isMonth(FEBRUARY);
     }
 
@@ -702,7 +738,7 @@ public abstract class LocalDateTimeMatchers {
      * assertThat(myDate, isMarch());
      * </pre>
      */
-    public static Matcher<LocalDateTime> isMarch() {
+    public static DateMatcher<LocalDateTime> isMarch() {
         return isMonth(MARCH);
     }
 
@@ -715,7 +751,7 @@ public abstract class LocalDateTimeMatchers {
      * assertThat(myDate, isApril());
      * </pre>
      */
-    public static Matcher<LocalDateTime> isApril() {
+    public static DateMatcher<LocalDateTime> isApril() {
         return isMonth(APRIL);
     }
 
@@ -728,7 +764,7 @@ public abstract class LocalDateTimeMatchers {
      * assertThat(myDate, isMay());
      * </pre>
      */
-    public static Matcher<LocalDateTime> isMay() {
+    public static DateMatcher<LocalDateTime> isMay() {
         return isMonth(MAY);
     }
 
@@ -741,7 +777,7 @@ public abstract class LocalDateTimeMatchers {
      * assertThat(myDate, isJune());
      * </pre>
      */
-    public static Matcher<LocalDateTime> isJune() {
+    public static DateMatcher<LocalDateTime> isJune() {
         return isMonth(JUNE);
     }
 
@@ -754,7 +790,7 @@ public abstract class LocalDateTimeMatchers {
      * assertThat(myDate, isJuly());
      * </pre>
      */
-    public static Matcher<LocalDateTime> isJuly() {
+    public static DateMatcher<LocalDateTime> isJuly() {
         return isMonth(JULY);
     }
 
@@ -767,7 +803,7 @@ public abstract class LocalDateTimeMatchers {
      * assertThat(myDate, isAugust());
      * </pre>
      */
-    public static Matcher<LocalDateTime> isAugust() {
+    public static DateMatcher<LocalDateTime> isAugust() {
         return isMonth(AUGUST);
     }
 
@@ -780,7 +816,7 @@ public abstract class LocalDateTimeMatchers {
      * assertThat(myDate, isSeptember());
      * </pre>
      */
-    public static Matcher<LocalDateTime> isSeptember() {
+    public static DateMatcher<LocalDateTime> isSeptember() {
         return isMonth(SEPTEMBER);
     }
 
@@ -793,7 +829,7 @@ public abstract class LocalDateTimeMatchers {
      * assertThat(myDate, isOctober());
      * </pre>
      */
-    public static Matcher<LocalDateTime> isOctober() {
+    public static DateMatcher<LocalDateTime> isOctober() {
         return isMonth(OCTOBER);
     }
 
@@ -806,7 +842,7 @@ public abstract class LocalDateTimeMatchers {
      * assertThat(myDate, isNovember());
      * </pre>
      */
-    public static Matcher<LocalDateTime> isNovember() {
+    public static DateMatcher<LocalDateTime> isNovember() {
         return isMonth(NOVEMBER);
     }
 
@@ -819,7 +855,7 @@ public abstract class LocalDateTimeMatchers {
      * assertThat(myDate, isDecember());
      * </pre>
      */
-    public static Matcher<LocalDateTime> isDecember() {
+    public static DateMatcher<LocalDateTime> isDecember() {
         return isMonth(DECEMBER);
     }
 
@@ -832,8 +868,8 @@ public abstract class LocalDateTimeMatchers {
      * assertThat(myDate, isLeapYear());
      * </pre>
      */
-    public static Matcher<LocalDateTime> isLeapYear() {
-        return new IsLeapYear<LocalDateTime>(t -> t, new LocalDateTimeFormatter());
+    public static DateMatcher<LocalDateTime> isLeapYear() {
+        return new IsLeapYear<>((d, z) -> d, new LocalDateTimeFormatter());
     }
 
     /**
@@ -847,8 +883,11 @@ public abstract class LocalDateTimeMatchers {
      *
      * @param hour the hour of the day (0-23)
      */
-    public static Matcher<LocalDateTime> isHour(final int hour) {
-        return new IsHour<LocalDateTime>(hour, t -> t);
+    public static DateMatcher<LocalDateTime> isHour(final int hour) {
+        return new IsHour<>(
+            new FieldLocalDateTimeWrapper(hour, ChronoField.HOUR_OF_DAY),
+            (d, z) -> ZonedDateTime.of(d, z).getHour()
+        );
     }
 
     /**
@@ -862,8 +901,11 @@ public abstract class LocalDateTimeMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<LocalDateTime> sameHourOfDay(final LocalDateTime date) {
-        return isHour(date.getHour());
+    public static DateMatcher<LocalDateTime> sameHourOfDay(final LocalDateTime date) {
+        return new IsHour<>(
+            new FieldLocalDateTimeWrapper(date, ChronoField.HOUR_OF_DAY),
+            (d, z) -> ZonedDateTime.of(d, z).getHour()
+        );
     }
 
     /**
@@ -875,10 +917,13 @@ public abstract class LocalDateTimeMatchers {
      * assertThat(myDate, isMinute(12));
      * </pre>
      *
-     * @param Minute the minute of the day (0-59)
+     * @param minute the minute of the day (0-59)
      */
-    public static Matcher<LocalDateTime> isMinute(final int minute) {
-        return new IsMinute<LocalDateTime>(minute, t -> t);
+    public static DateMatcher<LocalDateTime> isMinute(final int minute) {
+        return new IsMinute<>(
+            new FieldLocalDateTimeWrapper(minute, ChronoField.MINUTE_OF_HOUR),
+            (d, z) -> ZonedDateTime.of(d, z).getMinute()
+        );
     }
 
     /**
@@ -892,8 +937,11 @@ public abstract class LocalDateTimeMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<LocalDateTime> sameMinuteOfHour(final LocalDateTime date) {
-        return isMinute(date.getMinute());
+    public static DateMatcher<LocalDateTime> sameMinuteOfHour(final LocalDateTime date) {
+        return new IsMinute<>(
+            new FieldLocalDateTimeWrapper(date, ChronoField.MINUTE_OF_HOUR),
+            (d, z) -> ZonedDateTime.of(d, z).getMinute()
+        );
     }
 
     /**
@@ -905,10 +953,13 @@ public abstract class LocalDateTimeMatchers {
      * assertThat(myDate, isSecond(12));
      * </pre>
      *
-     * @param Second the second of the day (0-59)
+     * @param second the second of the day (0-59)
      */
-    public static Matcher<LocalDateTime> isSecond(final int Second) {
-        return new IsSecond<LocalDateTime>(Second, t -> t);
+    public static DateMatcher<LocalDateTime> isSecond(final int second) {
+        return new IsSecond<>(
+            new FieldLocalDateTimeWrapper(second, ChronoField.SECOND_OF_MINUTE),
+            (d, z) -> ZonedDateTime.of(d, z).getSecond()
+        );
     }
 
     /**
@@ -922,7 +973,10 @@ public abstract class LocalDateTimeMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<LocalDateTime> sameSecondOfMinute(final LocalDateTime date) {
-        return isSecond(date.getSecond());
+    public static DateMatcher<LocalDateTime> sameSecondOfMinute(final LocalDateTime date) {
+        return new IsSecond<>(
+            new FieldLocalDateTimeWrapper(date, ChronoField.SECOND_OF_MINUTE),
+            (d, z) -> ZonedDateTime.of(d, z).getSecond()
+        );
     }
 }

--- a/src/main/java/org/exparity/hamcrest/date/LocalTimeMatchers.java
+++ b/src/main/java/org/exparity/hamcrest/date/LocalTimeMatchers.java
@@ -4,18 +4,10 @@ import java.time.LocalTime;
 import java.time.temporal.ChronoField;
 import java.time.temporal.ChronoUnit;
 
-import org.exparity.hamcrest.date.core.IsAfter;
-import org.exparity.hamcrest.date.core.IsBefore;
-import org.exparity.hamcrest.date.core.IsHour;
-import org.exparity.hamcrest.date.core.IsMaximum;
-import org.exparity.hamcrest.date.core.IsMinimum;
-import org.exparity.hamcrest.date.core.IsMinute;
-import org.exparity.hamcrest.date.core.IsSameOrAfter;
-import org.exparity.hamcrest.date.core.IsSameOrBefore;
-import org.exparity.hamcrest.date.core.IsSecond;
-import org.exparity.hamcrest.date.core.IsWithin;
+import org.exparity.hamcrest.date.core.*;
 import org.exparity.hamcrest.date.core.format.DatePartFormatter;
 import org.exparity.hamcrest.date.core.format.LocalTimeFormatter;
+import org.exparity.hamcrest.date.core.wrapper.FieldLocalTimeWrapper;
 import org.exparity.hamcrest.date.core.wrapper.LocalTimeWrapper;
 import org.hamcrest.Factory;
 import org.hamcrest.Matcher;
@@ -39,7 +31,7 @@ public abstract class LocalTimeMatchers {
      * @param time the reference time against which the examined time is checked
      */
     public static Matcher<LocalTime> after(final LocalTime time) {
-        return new IsAfter<LocalTime>(new LocalTimeWrapper(time), new LocalTimeFormatter());
+        return new IsAfter<>(new LocalTimeWrapper(time), new LocalTimeFormatter());
     }
 
     /**
@@ -56,7 +48,7 @@ public abstract class LocalTimeMatchers {
      * @param second the second of the minute
      */
     public static Matcher<LocalTime> after(final int hour, final int minute, final int second) {
-        return new IsAfter<LocalTime>(new LocalTimeWrapper(hour, minute, second), new LocalTimeFormatter());
+        return new IsAfter<>(new LocalTimeWrapper(hour, minute, second), new LocalTimeFormatter());
     }
 
     /**
@@ -71,7 +63,7 @@ public abstract class LocalTimeMatchers {
      * @param time the reference time against which the examined time is checked
      */
     public static Matcher<LocalTime> before(final LocalTime time) {
-        return new IsBefore<LocalTime>(new LocalTimeWrapper(time), new LocalTimeFormatter());
+        return new IsBefore<>(new LocalTimeWrapper(time), new LocalTimeFormatter());
     }
 
     /**
@@ -88,7 +80,7 @@ public abstract class LocalTimeMatchers {
      * @param second the second of the minute
      */
     public static Matcher<LocalTime> before(final int hour, final int minute, final int second) {
-        return new IsBefore<LocalTime>(new LocalTimeWrapper(hour, minute, second), new LocalTimeFormatter());
+        return new IsBefore<>(new LocalTimeWrapper(hour, minute, second), new LocalTimeFormatter());
     }
 
     /**
@@ -103,7 +95,7 @@ public abstract class LocalTimeMatchers {
      * @param time the reference time against which the examined time is checked
      */
     public static Matcher<LocalTime> sameOrBefore(final LocalTime time) {
-        return new IsSameOrBefore<LocalTime>(new LocalTimeWrapper(time), new LocalTimeFormatter());
+        return new IsSameOrBefore<>(new LocalTimeWrapper(time), new LocalTimeFormatter());
     }
 
     /**
@@ -122,7 +114,7 @@ public abstract class LocalTimeMatchers {
      */
     @Factory
     public static Matcher<LocalTime> sameOrBefore(final int hour, final int minute, final int second) {
-        return new IsSameOrBefore<LocalTime>(new LocalTimeWrapper(hour, minute, second), new LocalTimeFormatter());
+        return new IsSameOrBefore<>(new LocalTimeWrapper(hour, minute, second), new LocalTimeFormatter());
     }
 
     /**
@@ -137,7 +129,7 @@ public abstract class LocalTimeMatchers {
      * @param time the reference time against which the examined time is checked
      */
     public static Matcher<LocalTime> sameOrAfter(final LocalTime time) {
-        return new IsSameOrAfter<LocalTime>(new LocalTimeWrapper(time), new LocalTimeFormatter());
+        return new IsSameOrAfter<>(new LocalTimeWrapper(time), new LocalTimeFormatter());
     }
 
     /**
@@ -169,7 +161,7 @@ public abstract class LocalTimeMatchers {
      * @param time the reference time against which the examined time is checked
      */
     public static Matcher<LocalTime> within(final long period, final ChronoUnit unit, final LocalTime time) {
-        return new IsWithin<LocalTime>(period, unit, new LocalTimeWrapper(time), new LocalTimeFormatter());
+        return new IsWithin<>(period, unit, new LocalTimeWrapper(time), new LocalTimeFormatter());
     }
 
     /**
@@ -192,10 +184,10 @@ public abstract class LocalTimeMatchers {
             final int hour,
             final int minute,
             final int second) {
-        return new IsWithin<LocalTime>(period,
-                unit,
-                new LocalTimeWrapper(hour, minute, second),
-                new LocalTimeFormatter());
+        return new IsWithin<>(period,
+            unit,
+            new LocalTimeWrapper(hour, minute, second),
+            new LocalTimeFormatter());
     }
 
     /**
@@ -211,7 +203,12 @@ public abstract class LocalTimeMatchers {
      * @param field the temporal field to check
      */
     public static Matcher<LocalTime> isMinimum(final ChronoField field) {
-        return new IsMinimum<LocalTime>(field, t -> t, new DatePartFormatter());
+        return new IsMinimum<>(
+            field,
+            (d, z) -> d.get(field),
+            (d, z) -> field.rangeRefinedBy(d),
+            new DatePartFormatter()
+        );
     }
 
     /**
@@ -227,7 +224,12 @@ public abstract class LocalTimeMatchers {
      * @param field the temporal field to check
      */
     public static Matcher<LocalTime> isMaximum(final ChronoField field) {
-        return new IsMaximum<LocalTime>(field, t -> t, new DatePartFormatter());
+        return new IsMaximum<>(
+            field,
+            (d, z) -> d.get(field),
+            (d, z) -> field.rangeRefinedBy(d),
+            new DatePartFormatter()
+        );
     }
 
     /**
@@ -242,7 +244,10 @@ public abstract class LocalTimeMatchers {
      * @param hour the hour of the day (0-23)
      */
     public static Matcher<LocalTime> isHour(final int hour) {
-        return new IsHour<LocalTime>(hour, t -> t);
+        return new IsHour<>(
+            new FieldLocalTimeWrapper(hour, ChronoField.HOUR_OF_DAY),
+            (d, ignored) -> d.getHour()
+        );
     }
 
     /**
@@ -257,7 +262,10 @@ public abstract class LocalTimeMatchers {
      * @param time the reference time against which the examined time is checked
      */
     public static Matcher<LocalTime> sameHourOfDay(final LocalTime time) {
-        return isHour(time.getHour());
+        return new IsHour<>(
+            new FieldLocalTimeWrapper(time, ChronoField.HOUR_OF_DAY),
+            (d, ignored) -> d.getHour()
+        );
     }
 
     /**
@@ -269,10 +277,13 @@ public abstract class LocalTimeMatchers {
      * assertThat(myTime, isMinute(12));
      * </pre>
      *
-     * @param Minute the minute of the day (0-59)
+     * @param minute the minute of the day (0-59)
      */
     public static Matcher<LocalTime> isMinute(final int minute) {
-        return new IsMinute<LocalTime>(minute, t -> t);
+        return new IsMinute<>(
+            new FieldLocalTimeWrapper(minute, ChronoField.MINUTE_OF_HOUR),
+            (d, ignored) -> d.getMinute()
+        );
     }
 
     /**
@@ -287,7 +298,10 @@ public abstract class LocalTimeMatchers {
      * @param time the reference time against which the examined time is checked
      */
     public static Matcher<LocalTime> sameMinuteOfHour(final LocalTime time) {
-        return isMinute(time.getMinute());
+        return new IsMinute<>(
+            new FieldLocalTimeWrapper(time, ChronoField.MINUTE_OF_HOUR),
+            (d, ignored) -> d.getMinute()
+        );
     }
 
     /**
@@ -299,10 +313,13 @@ public abstract class LocalTimeMatchers {
      * assertThat(myTime, isSecond(12));
      * </pre>
      *
-     * @param Second the second of the day (0-59)
+     * @param second the second of the day (0-59)
      */
-    public static Matcher<LocalTime> isSecond(final int Second) {
-        return new IsSecond<LocalTime>(Second, t -> t);
+    public static Matcher<LocalTime> isSecond(final int second) {
+        return new IsSecond<>(
+            new FieldLocalTimeWrapper(second, ChronoField.SECOND_OF_MINUTE),
+            (d, ignored) -> d.getSecond()
+        );
     }
 
     /**
@@ -317,6 +334,9 @@ public abstract class LocalTimeMatchers {
      * @param time the reference time against which the examined time is checked
      */
     public static Matcher<LocalTime> sameSecondOfMinute(final LocalTime time) {
-        return isSecond(time.getSecond());
+        return new IsSecond<>(
+            new FieldLocalTimeWrapper(time, ChronoField.SECOND_OF_MINUTE),
+            (d, ignored) -> d.getSecond()
+        );
     }
 }

--- a/src/main/java/org/exparity/hamcrest/date/Months.java
+++ b/src/main/java/org/exparity/hamcrest/date/Months.java
@@ -48,11 +48,11 @@ public enum Months {
 		throw new IllegalArgumentException("Unknown calendar month value '" + calendarMonth + "'");
 	}
 
-	private final int calendarMonth;;
-	private final Month month;
+	private final int calendarMonth;
+  private final Month month;
 	private final String description;
 
-	private Months(final int calendarMonth, final Month month, final String description) {
+	Months(final int calendarMonth, final Month month, final String description) {
 		this.calendarMonth = calendarMonth;
 		this.month = month;
 		this.description = description;

--- a/src/main/java/org/exparity/hamcrest/date/Weekdays.java
+++ b/src/main/java/org/exparity/hamcrest/date/Weekdays.java
@@ -25,7 +25,7 @@ public enum Weekdays {
 	private final int calendarDay;
 	private final DayOfWeek dayOfWeek;
 
-	private Weekdays(final int calendarDay, final DayOfWeek dayOfWeek) {
+	Weekdays(final int calendarDay, final DayOfWeek dayOfWeek) {
 		this.calendarDay = calendarDay;
 		this.dayOfWeek = dayOfWeek;
 	}

--- a/src/main/java/org/exparity/hamcrest/date/ZonedDateTimeMatchers.java
+++ b/src/main/java/org/exparity/hamcrest/date/ZonedDateTimeMatchers.java
@@ -1,8 +1,24 @@
 package org.exparity.hamcrest.date;
 
-import static java.time.DayOfWeek.*;
-import static java.time.Month.*;
-import static java.util.Arrays.asList;
+import static java.time.DayOfWeek.FRIDAY;
+import static java.time.DayOfWeek.MONDAY;
+import static java.time.DayOfWeek.SATURDAY;
+import static java.time.DayOfWeek.SUNDAY;
+import static java.time.DayOfWeek.THURSDAY;
+import static java.time.DayOfWeek.TUESDAY;
+import static java.time.DayOfWeek.WEDNESDAY;
+import static java.time.Month.APRIL;
+import static java.time.Month.AUGUST;
+import static java.time.Month.DECEMBER;
+import static java.time.Month.FEBRUARY;
+import static java.time.Month.JANUARY;
+import static java.time.Month.JULY;
+import static java.time.Month.JUNE;
+import static java.time.Month.MARCH;
+import static java.time.Month.MAY;
+import static java.time.Month.NOVEMBER;
+import static java.time.Month.OCTOBER;
+import static java.time.Month.SEPTEMBER;
 
 import java.time.DayOfWeek;
 import java.time.Month;
@@ -10,29 +26,14 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoField;
 import java.time.temporal.ChronoUnit;
+import java.util.stream.Stream;
 
-import org.exparity.hamcrest.date.core.IsAfter;
-import org.exparity.hamcrest.date.core.IsBefore;
-import org.exparity.hamcrest.date.core.IsDayOfMonth;
-import org.exparity.hamcrest.date.core.IsDayOfWeek;
-import org.exparity.hamcrest.date.core.IsHour;
-import org.exparity.hamcrest.date.core.IsLeapYear;
-import org.exparity.hamcrest.date.core.IsMaximum;
-import org.exparity.hamcrest.date.core.IsMinimum;
-import org.exparity.hamcrest.date.core.IsMinute;
-import org.exparity.hamcrest.date.core.IsMonth;
-import org.exparity.hamcrest.date.core.IsSame;
-import org.exparity.hamcrest.date.core.IsSameDay;
-import org.exparity.hamcrest.date.core.IsSameOrAfter;
-import org.exparity.hamcrest.date.core.IsSameOrBefore;
-import org.exparity.hamcrest.date.core.IsSecond;
-import org.exparity.hamcrest.date.core.IsWithin;
-import org.exparity.hamcrest.date.core.IsYear;
+import org.exparity.hamcrest.date.core.*;
 import org.exparity.hamcrest.date.core.format.DatePartFormatter;
 import org.exparity.hamcrest.date.core.format.ZonedDateTimeFormatter;
+import org.exparity.hamcrest.date.core.wrapper.FieldZonedDateTimeWrapper;
 import org.exparity.hamcrest.date.core.wrapper.ZonedDateTimeWrapper;
 import org.hamcrest.Factory;
-import org.hamcrest.Matcher;
 
 /**
  * Static factory for creating {@link org.hamcrest.Matcher} instances for comparing {@link ZonedDateTime} instances
@@ -52,8 +53,8 @@ public abstract class ZonedDateTimeMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<ZonedDateTime> after(final ZonedDateTime date) {
-        return new IsAfter<ZonedDateTime>(new ZonedDateTimeWrapper(date), new ZonedDateTimeFormatter());
+    public static DateMatcher<ZonedDateTime> after(final ZonedDateTime date) {
+        return new IsAfter<>(new ZonedDateTimeWrapper(date), new ZonedDateTimeFormatter());
     }
 
     /**
@@ -73,7 +74,7 @@ public abstract class ZonedDateTimeMatchers {
      * @param second the second of the minute
      * @param nanos the nanos of the second
      */
-    public static Matcher<ZonedDateTime> after(final int year,
+    public static DateMatcher<ZonedDateTime> after(final int year,
             final Month month,
             final int dayOfMonth,
             final int hour,
@@ -81,9 +82,9 @@ public abstract class ZonedDateTimeMatchers {
             final int second,
             final int nanos,
             final ZoneId tz) {
-        return new IsAfter<ZonedDateTime>(
-                new ZonedDateTimeWrapper(year, month, dayOfMonth, hour, minute, second, nanos, tz),
-                new ZonedDateTimeFormatter());
+        return new IsAfter<>(
+            new ZonedDateTimeWrapper(year, month, dayOfMonth, hour, minute, second, nanos, tz),
+            new ZonedDateTimeFormatter());
     }
 
     /**
@@ -97,8 +98,8 @@ public abstract class ZonedDateTimeMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<ZonedDateTime> before(final ZonedDateTime date) {
-        return new IsBefore<ZonedDateTime>(new ZonedDateTimeWrapper(date), new ZonedDateTimeFormatter());
+    public static DateMatcher<ZonedDateTime> before(final ZonedDateTime date) {
+        return new IsBefore<>(new ZonedDateTimeWrapper(date), new ZonedDateTimeFormatter());
     }
 
     /**
@@ -118,7 +119,7 @@ public abstract class ZonedDateTimeMatchers {
      * @param second the second of the minute
      * @param nanos the nanoseconds of the second
      */
-    public static Matcher<ZonedDateTime> before(final int year,
+    public static DateMatcher<ZonedDateTime> before(final int year,
             final Month month,
             final int dayOfMonth,
             final int hour,
@@ -126,8 +127,8 @@ public abstract class ZonedDateTimeMatchers {
             final int second,
             final int nanos,
             final ZoneId tz) {
-        return new IsBefore<ZonedDateTime>(new ZonedDateTimeWrapper(year, month, dayOfMonth, hour, minute, second, tz),
-                new ZonedDateTimeFormatter());
+        return new IsBefore<>(new ZonedDateTimeWrapper(year, month, dayOfMonth, hour, minute, second, tz),
+            new ZonedDateTimeFormatter());
     }
 
     /**
@@ -141,8 +142,8 @@ public abstract class ZonedDateTimeMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<ZonedDateTime> sameDay(final ZonedDateTime date) {
-        return new IsSameDay<ZonedDateTime>(new ZonedDateTimeWrapper(date), new ZonedDateTimeFormatter());
+    public static DateMatcher<ZonedDateTime> sameDay(final ZonedDateTime date) {
+        return new IsSameDay<>(new ZonedDateTimeWrapper(date, ChronoUnit.DAYS), new ZonedDateTimeFormatter());
     }
 
     /**
@@ -159,12 +160,12 @@ public abstract class ZonedDateTimeMatchers {
      * @param year the reference year against which the examined date is checked
      * @param tz the reference time zone
      */
-    public static Matcher<ZonedDateTime> isDay(final int year,
+    public static DateMatcher<ZonedDateTime> isDay(final int year,
             final Month month,
             final int dayOfMonth,
             final ZoneId tz) {
-        return new IsSameDay<ZonedDateTime>(new ZonedDateTimeWrapper(year, month, dayOfMonth, tz),
-                new ZonedDateTimeFormatter());
+        return new IsSameDay<>(new ZonedDateTimeWrapper(year, month, dayOfMonth, tz),
+            new ZonedDateTimeFormatter());
     }
 
     /**
@@ -178,8 +179,8 @@ public abstract class ZonedDateTimeMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<ZonedDateTime> sameInstant(final ZonedDateTime date) {
-        return new IsSame<ZonedDateTime>(new ZonedDateTimeWrapper(date), new ZonedDateTimeFormatter());
+    public static DateMatcher<ZonedDateTime> sameInstant(final ZonedDateTime date) {
+        return new IsSame<>(new ZonedDateTimeWrapper(date), new ZonedDateTimeFormatter());
     }
 
     /**
@@ -200,7 +201,7 @@ public abstract class ZonedDateTimeMatchers {
      * @param nanos the nanosecond of the second
      * @param tz the timezone
      */
-    public static Matcher<ZonedDateTime> isInstant(final int year,
+    public static DateMatcher<ZonedDateTime> isInstant(final int year,
             final Month month,
             final int dayOfMonth,
             final int hour,
@@ -208,9 +209,9 @@ public abstract class ZonedDateTimeMatchers {
             final int second,
             final int nanos,
             final ZoneId tz) {
-        return new IsSame<ZonedDateTime>(
-                new ZonedDateTimeWrapper(year, month, dayOfMonth, hour, minute, second, nanos, tz),
-                new ZonedDateTimeFormatter());
+        return new IsSame<>(
+            new ZonedDateTimeWrapper(year, month, dayOfMonth, hour, minute, second, nanos, tz),
+            new ZonedDateTimeFormatter());
     }
 
     /**
@@ -224,8 +225,8 @@ public abstract class ZonedDateTimeMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<ZonedDateTime> sameOrBefore(final ZonedDateTime date) {
-        return new IsSameOrBefore<ZonedDateTime>(new ZonedDateTimeWrapper(date), new ZonedDateTimeFormatter());
+    public static DateMatcher<ZonedDateTime> sameOrBefore(final ZonedDateTime date) {
+        return new IsSameOrBefore<>(new ZonedDateTimeWrapper(date), new ZonedDateTimeFormatter());
     }
 
     /**
@@ -248,7 +249,7 @@ public abstract class ZonedDateTimeMatchers {
      * @param tz the time zone of the date to check against
      */
     @Factory
-    public static Matcher<ZonedDateTime> sameOrBefore(final int year,
+    public static DateMatcher<ZonedDateTime> sameOrBefore(final int year,
             final Month month,
             final int day,
             final int hour,
@@ -256,9 +257,9 @@ public abstract class ZonedDateTimeMatchers {
             final int second,
             final int nanos,
             final ZoneId tz) {
-        return new IsSameOrBefore<ZonedDateTime>(
-                new ZonedDateTimeWrapper(year, month, day, hour, minute, second, nanos, tz),
-                new ZonedDateTimeFormatter());
+        return new IsSameOrBefore<>(
+            new ZonedDateTimeWrapper(year, month, day, hour, minute, second, nanos, tz),
+            new ZonedDateTimeFormatter());
     }
 
     /**
@@ -272,8 +273,8 @@ public abstract class ZonedDateTimeMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<ZonedDateTime> sameOrAfter(final ZonedDateTime date) {
-        return new IsSameOrAfter<ZonedDateTime>(new ZonedDateTimeWrapper(date), new ZonedDateTimeFormatter());
+    public static DateMatcher<ZonedDateTime> sameOrAfter(final ZonedDateTime date) {
+        return new IsSameOrAfter<>(new ZonedDateTimeWrapper(date), new ZonedDateTimeFormatter());
     }
 
     /**
@@ -296,7 +297,7 @@ public abstract class ZonedDateTimeMatchers {
      * @param tz the time zone of the date to check against
      */
     @Factory
-    public static Matcher<ZonedDateTime> sameOrAfter(final int year,
+    public static DateMatcher<ZonedDateTime> sameOrAfter(final int year,
             final Month month,
             final int day,
             final int hour,
@@ -304,9 +305,9 @@ public abstract class ZonedDateTimeMatchers {
             final int second,
             final int nanos,
             final ZoneId tz) {
-        return new IsSameOrAfter<ZonedDateTime>(
-                new ZonedDateTimeWrapper(year, month, day, hour, minute, second, nanos, tz),
-                new ZonedDateTimeFormatter());
+        return new IsSameOrAfter<>(
+            new ZonedDateTimeWrapper(year, month, day, hour, minute, second, nanos, tz),
+            new ZonedDateTimeFormatter());
     }
 
     /**
@@ -320,8 +321,11 @@ public abstract class ZonedDateTimeMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<ZonedDateTime> sameMonthOfYear(final ZonedDateTime date) {
-        return isMonth(date.getMonth());
+    public static DateMatcher<ZonedDateTime> sameMonthOfYear(final ZonedDateTime date) {
+        return new IsMonth<>(
+            new FieldZonedDateTimeWrapper(date, ChronoField.MONTH_OF_YEAR),
+            (d, z) -> ZonedDateTime.ofInstant(d.toInstant(), z).get(ChronoField.MONTH_OF_YEAR)
+        );
     }
 
     /**
@@ -335,8 +339,11 @@ public abstract class ZonedDateTimeMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<ZonedDateTime> sameDayOfMonth(final ZonedDateTime date) {
-        return isDayOfMonth(date.getDayOfMonth());
+    public static DateMatcher<ZonedDateTime> sameDayOfMonth(final ZonedDateTime date) {
+        return new IsDayOfMonth<>(
+            new FieldZonedDateTimeWrapper(date, ChronoField.DAY_OF_MONTH),
+            (d, z) -> ZonedDateTime.ofInstant(d.toInstant(), z).get(ChronoField.DAY_OF_MONTH)
+        );
     }
 
     /**
@@ -348,10 +355,13 @@ public abstract class ZonedDateTimeMatchers {
      * assertThat(myDate, isDayOfMonth(4))
      * </pre>
      *
-     * @param date the expected day of the month
+     * @param dayOfMonth the expected day of the month
      */
-    public static Matcher<ZonedDateTime> isDayOfMonth(final int dayOfMonth) {
-        return new IsDayOfMonth<ZonedDateTime>(dayOfMonth, t -> t);
+    public static DateMatcher<ZonedDateTime> isDayOfMonth(final int dayOfMonth) {
+        return new IsDayOfMonth<>(
+            new FieldZonedDateTimeWrapper(dayOfMonth, ChronoField.DAY_OF_MONTH),
+            (d, z) -> ZonedDateTime.ofInstant(d.toInstant(), z).get(ChronoField.DAY_OF_MONTH)
+        );
     }
 
     /**
@@ -365,7 +375,7 @@ public abstract class ZonedDateTimeMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<ZonedDateTime> sameYear(final ZonedDateTime date) {
+    public static DateMatcher<ZonedDateTime> sameYear(final ZonedDateTime date) {
         return isYear(date.getYear());
     }
 
@@ -380,8 +390,11 @@ public abstract class ZonedDateTimeMatchers {
      *
      * @param year the reference year against which the examined date is checked
      */
-    public static Matcher<ZonedDateTime> isYear(final int year) {
-        return new IsYear<ZonedDateTime>(year, t -> t);
+    public static DateMatcher<ZonedDateTime> isYear(final int year) {
+        return new IsYear<>(
+            new FieldZonedDateTimeWrapper(year, ChronoField.YEAR),
+            (d, z) -> ZonedDateTime.ofInstant(d.toInstant(), z).get(ChronoField.YEAR)
+        );
     }
 
     /**
@@ -395,8 +408,8 @@ public abstract class ZonedDateTimeMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<ZonedDateTime> within(final long period, final ChronoUnit unit, final ZonedDateTime date) {
-        return new IsWithin<ZonedDateTime>(period, unit, new ZonedDateTimeWrapper(date), new ZonedDateTimeFormatter());
+    public static DateMatcher<ZonedDateTime> within(final long period, final ChronoUnit unit, final ZonedDateTime date) {
+        return new IsWithin<>(period, unit, new ZonedDateTimeWrapper(date), new ZonedDateTimeFormatter());
     }
 
     /**
@@ -413,17 +426,13 @@ public abstract class ZonedDateTimeMatchers {
      * @param year the year against which the examined date is checked
      * @param month the month against which the examined date is checked
      * @param dayofMonth the day of the month against which the examined date is checked
-     * @param hour
      * @param hour the hour of the day
      * @param minute the minute of the hour
      * @param second the second of the minute
-     * @param hour the hour of the day
-     * @param minute the minute of the hour
-     * @param second the second of the minute
-     * @param nanos the nanonseconds of the second
+     * @param nanos the nanoseconds of the second
      * @param tz the time zone of the reference date
      */
-    public static Matcher<ZonedDateTime> within(final long period,
+    public static DateMatcher<ZonedDateTime> within(final long period,
             final ChronoUnit unit,
             final int year,
             final Month month,
@@ -433,10 +442,10 @@ public abstract class ZonedDateTimeMatchers {
             final int second,
             final int nanos,
             final ZoneId tz) {
-        return new IsWithin<ZonedDateTime>(period,
-                unit,
-                new ZonedDateTimeWrapper(year, month, dayofMonth, hour, minute, second, nanos, tz),
-                new ZonedDateTimeFormatter());
+        return new IsWithin<>(period,
+            unit,
+            new ZonedDateTimeWrapper(year, month, dayofMonth, hour, minute, second, nanos, tz),
+            new ZonedDateTimeFormatter());
     }
 
     /**
@@ -448,7 +457,7 @@ public abstract class ZonedDateTimeMatchers {
      * assertThat(myDate, isToday());
      * </pre>
      */
-    public static Matcher<ZonedDateTime> isYesterday() {
+    public static DateMatcher<ZonedDateTime> isYesterday() {
         return sameDay(ZonedDateTime.now().plusDays(-1));
     }
 
@@ -461,7 +470,7 @@ public abstract class ZonedDateTimeMatchers {
      * assertThat(myDate, isToday());
      * </pre>
      */
-    public static Matcher<ZonedDateTime> isToday() {
+    public static DateMatcher<ZonedDateTime> isToday() {
         return sameDay(ZonedDateTime.now());
     }
 
@@ -474,7 +483,7 @@ public abstract class ZonedDateTimeMatchers {
      * assertThat(myDate, isTomorrow());
      * </pre>
      */
-    public static Matcher<ZonedDateTime> isTomorrow() {
+    public static DateMatcher<ZonedDateTime> isTomorrow() {
         return sameDay(ZonedDateTime.now().plusDays(1));
     }
 
@@ -489,12 +498,12 @@ public abstract class ZonedDateTimeMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<ZonedDateTime> sameDayOfWeek(final ZonedDateTime date) {
+    public static DateMatcher<ZonedDateTime> sameDayOfWeek(final ZonedDateTime date) {
         return isDayOfWeek(DayOfWeek.from(date));
     }
 
     /**
-     * Creates a matcher that matches when the examined date is on a monday
+     * Creates a matcher that matches when the examined date is on the same day of the week as the supplied day
      * <p/>
      * For example:
      *
@@ -502,8 +511,27 @@ public abstract class ZonedDateTimeMatchers {
      * assertThat(myDate, isMonday());
      * </pre>
      */
-    public static Matcher<ZonedDateTime> isDayOfWeek(final DayOfWeek... dayOfWeek) {
-        return new IsDayOfWeek<ZonedDateTime>(asList(dayOfWeek), t -> t);
+    public static DateMatcher<ZonedDateTime> isDayOfWeek(final DayOfWeek dayOfWeek) {
+        return new IsDayOfWeek<>(
+            new FieldZonedDateTimeWrapper(dayOfWeek.getValue(), ChronoField.DAY_OF_WEEK),
+            (d, z) -> ZonedDateTime.ofInstant(d.toInstant(), z).get(ChronoField.DAY_OF_WEEK)
+        );
+    }
+
+    /**
+     * Creates a matcher that matches when the examined date is on the same day of the week as any of the supplied days
+     * <p/>
+     * For example:
+     *
+     * <pre>
+     * assertThat(myDate, isMonday());
+     * </pre>
+     */
+    public static DateMatcher<ZonedDateTime> isDayOfWeek(final DayOfWeek... daysOfWeek) {
+        return new AnyOf<>(
+            Stream.of(daysOfWeek).map(ZonedDateTimeMatchers::isDayOfWeek),
+            (d, z) -> "the date is on a " + d.withZoneSameInstant(z).getDayOfWeek().name().toLowerCase()
+        );
     }
 
     /**
@@ -515,7 +543,7 @@ public abstract class ZonedDateTimeMatchers {
      * assertThat(myDate, isMonday());
      * </pre>
      */
-    public static Matcher<ZonedDateTime> isMonday() {
+    public static DateMatcher<ZonedDateTime> isMonday() {
         return isDayOfWeek(MONDAY);
     }
 
@@ -528,7 +556,7 @@ public abstract class ZonedDateTimeMatchers {
      * assertThat(myDate, isTuesday());
      * </pre>
      */
-    public static Matcher<ZonedDateTime> isTuesday() {
+    public static DateMatcher<ZonedDateTime> isTuesday() {
         return isDayOfWeek(TUESDAY);
     }
 
@@ -541,7 +569,7 @@ public abstract class ZonedDateTimeMatchers {
      * assertThat(myDate, isWednesday());
      * </pre>
      */
-    public static Matcher<ZonedDateTime> isWednesday() {
+    public static DateMatcher<ZonedDateTime> isWednesday() {
         return isDayOfWeek(WEDNESDAY);
     }
 
@@ -554,7 +582,7 @@ public abstract class ZonedDateTimeMatchers {
      * assertThat(myDate, isThursday());
      * </pre>
      */
-    public static Matcher<ZonedDateTime> isThursday() {
+    public static DateMatcher<ZonedDateTime> isThursday() {
         return isDayOfWeek(THURSDAY);
     }
 
@@ -567,7 +595,7 @@ public abstract class ZonedDateTimeMatchers {
      * assertThat(myDate, isFriday());
      * </pre>
      */
-    public static Matcher<ZonedDateTime> isFriday() {
+    public static DateMatcher<ZonedDateTime> isFriday() {
         return isDayOfWeek(FRIDAY);
     }
 
@@ -580,7 +608,7 @@ public abstract class ZonedDateTimeMatchers {
      * assertThat(myDate, isSaturday());
      * </pre>
      */
-    public static Matcher<ZonedDateTime> isSaturday() {
+    public static DateMatcher<ZonedDateTime> isSaturday() {
         return isDayOfWeek(SATURDAY);
     }
 
@@ -593,7 +621,7 @@ public abstract class ZonedDateTimeMatchers {
      * assertThat(myDate, isSunday());
      * </pre>
      */
-    public static Matcher<ZonedDateTime> isSunday() {
+    public static DateMatcher<ZonedDateTime> isSunday() {
         return isDayOfWeek(SUNDAY);
     }
 
@@ -606,7 +634,7 @@ public abstract class ZonedDateTimeMatchers {
      * assertThat(myDate, isWeekday());
      * </pre>
      */
-    public static Matcher<ZonedDateTime> isWeekday() {
+    public static DateMatcher<ZonedDateTime> isWeekday() {
         return isDayOfWeek(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY);
     }
 
@@ -619,7 +647,7 @@ public abstract class ZonedDateTimeMatchers {
      * assertThat(myDate, isWeekend());
      * </pre>
      */
-    public static Matcher<ZonedDateTime> isWeekend() {
+    public static DateMatcher<ZonedDateTime> isWeekend() {
         return isDayOfWeek(SATURDAY, SUNDAY);
     }
 
@@ -632,11 +660,12 @@ public abstract class ZonedDateTimeMatchers {
      * assertThat(myDate, isFirstDayOfMonth());
      * </pre>
      */
-    public static Matcher<ZonedDateTime> isFirstDayOfMonth() {
-        return new IsMinimum<ZonedDateTime>(ChronoField.DAY_OF_MONTH,
-                t -> t,
-                new DatePartFormatter(),
-                () -> "the date is the first day of the month");
+    public static DateMatcher<ZonedDateTime> isFirstDayOfMonth() {
+        return new IsMinimum<>(ChronoField.DAY_OF_MONTH,
+            (d, z) -> d.withZoneSameInstant(z).get(ChronoField.DAY_OF_MONTH),
+            (d, z) -> ChronoField.DAY_OF_MONTH.rangeRefinedBy(d.withZoneSameInstant(z)),
+            new DatePartFormatter(),
+            () -> "the date is the first day of the month");
     }
 
     /**
@@ -651,8 +680,13 @@ public abstract class ZonedDateTimeMatchers {
      *
      * @param field the temporal field to check
      */
-    public static Matcher<ZonedDateTime> isMinimum(final ChronoField field) {
-        return new IsMinimum<ZonedDateTime>(field, t -> t, new DatePartFormatter());
+    public static DateMatcher<ZonedDateTime> isMinimum(final ChronoField field) {
+        return new IsMinimum<>(
+            field,
+            (d, z) -> d.withZoneSameInstant(z).get(field),
+            (d, z) -> field.rangeRefinedBy(d.withZoneSameInstant(z)),
+            new DatePartFormatter()
+        );
     }
 
     /**
@@ -664,11 +698,14 @@ public abstract class ZonedDateTimeMatchers {
      * assertThat(myDate, isFirstDayOfMonth());
      * </pre>
      */
-    public static Matcher<ZonedDateTime> isLastDayOfMonth() {
-        return new IsMaximum<ZonedDateTime>(ChronoField.DAY_OF_MONTH,
-                t -> t,
-                new DatePartFormatter(),
-                () -> "the date is the last day of the month");
+    public static DateMatcher<ZonedDateTime> isLastDayOfMonth() {
+        return new IsMaximum<>(
+            ChronoField.DAY_OF_MONTH,
+            (d, z) -> d.withZoneSameInstant(z).get(ChronoField.DAY_OF_MONTH),
+            (d, z) -> ChronoField.DAY_OF_MONTH.rangeRefinedBy(d.withZoneSameInstant(z)),
+            new DatePartFormatter(),
+            () -> "the date is the last day of the month"
+        );
     }
 
     /**
@@ -683,8 +720,13 @@ public abstract class ZonedDateTimeMatchers {
      *
      * @param field the temporal field to check
      */
-    public static Matcher<ZonedDateTime> isMaximum(final ChronoField field) {
-        return new IsMaximum<ZonedDateTime>(field, t -> t, new DatePartFormatter());
+    public static DateMatcher<ZonedDateTime> isMaximum(final ChronoField field) {
+        return new IsMaximum<>(
+            field,
+            (d, z) -> d.withZoneSameInstant(z).get(field),
+            (d, z) -> field.rangeRefinedBy(d.withZoneSameInstant(z)),
+            new DatePartFormatter()
+        );
     }
 
     /**
@@ -696,8 +738,11 @@ public abstract class ZonedDateTimeMatchers {
      * assertThat(myDate, isMonth(Month.AUGUST));
      * </pre>
      */
-    public static Matcher<ZonedDateTime> isMonth(final Month month) {
-        return new IsMonth<ZonedDateTime>(month, t -> t);
+    public static DateMatcher<ZonedDateTime> isMonth(final Month month) {
+        return new IsMonth<>(
+            new FieldZonedDateTimeWrapper(month.getValue(), ChronoField.MONTH_OF_YEAR),
+            (d, z) -> ZonedDateTime.ofInstant(d.toInstant(), z).get(ChronoField.MONTH_OF_YEAR)
+        );
     }
 
     /**
@@ -709,7 +754,7 @@ public abstract class ZonedDateTimeMatchers {
      * assertThat(myDate, isJanuary());
      * </pre>
      */
-    public static Matcher<ZonedDateTime> isJanuary() {
+    public static DateMatcher<ZonedDateTime> isJanuary() {
         return isMonth(JANUARY);
     }
 
@@ -722,7 +767,7 @@ public abstract class ZonedDateTimeMatchers {
      * assertThat(myDate, isFebruary());
      * </pre>
      */
-    public static Matcher<ZonedDateTime> isFebruary() {
+    public static DateMatcher<ZonedDateTime> isFebruary() {
         return isMonth(FEBRUARY);
     }
 
@@ -735,7 +780,7 @@ public abstract class ZonedDateTimeMatchers {
      * assertThat(myDate, isMarch());
      * </pre>
      */
-    public static Matcher<ZonedDateTime> isMarch() {
+    public static DateMatcher<ZonedDateTime> isMarch() {
         return isMonth(MARCH);
     }
 
@@ -748,7 +793,7 @@ public abstract class ZonedDateTimeMatchers {
      * assertThat(myDate, isApril());
      * </pre>
      */
-    public static Matcher<ZonedDateTime> isApril() {
+    public static DateMatcher<ZonedDateTime> isApril() {
         return isMonth(APRIL);
     }
 
@@ -761,7 +806,7 @@ public abstract class ZonedDateTimeMatchers {
      * assertThat(myDate, isMay());
      * </pre>
      */
-    public static Matcher<ZonedDateTime> isMay() {
+    public static DateMatcher<ZonedDateTime> isMay() {
         return isMonth(MAY);
     }
 
@@ -774,7 +819,7 @@ public abstract class ZonedDateTimeMatchers {
      * assertThat(myDate, isJune());
      * </pre>
      */
-    public static Matcher<ZonedDateTime> isJune() {
+    public static DateMatcher<ZonedDateTime> isJune() {
         return isMonth(JUNE);
     }
 
@@ -787,7 +832,7 @@ public abstract class ZonedDateTimeMatchers {
      * assertThat(myDate, isJuly());
      * </pre>
      */
-    public static Matcher<ZonedDateTime> isJuly() {
+    public static DateMatcher<ZonedDateTime> isJuly() {
         return isMonth(JULY);
     }
 
@@ -800,7 +845,7 @@ public abstract class ZonedDateTimeMatchers {
      * assertThat(myDate, isAugust());
      * </pre>
      */
-    public static Matcher<ZonedDateTime> isAugust() {
+    public static DateMatcher<ZonedDateTime> isAugust() {
         return isMonth(AUGUST);
     }
 
@@ -813,7 +858,7 @@ public abstract class ZonedDateTimeMatchers {
      * assertThat(myDate, isSeptember());
      * </pre>
      */
-    public static Matcher<ZonedDateTime> isSeptember() {
+    public static DateMatcher<ZonedDateTime> isSeptember() {
         return isMonth(SEPTEMBER);
     }
 
@@ -826,7 +871,7 @@ public abstract class ZonedDateTimeMatchers {
      * assertThat(myDate, isOctober());
      * </pre>
      */
-    public static Matcher<ZonedDateTime> isOctober() {
+    public static DateMatcher<ZonedDateTime> isOctober() {
         return isMonth(OCTOBER);
     }
 
@@ -839,7 +884,7 @@ public abstract class ZonedDateTimeMatchers {
      * assertThat(myDate, isNovember());
      * </pre>
      */
-    public static Matcher<ZonedDateTime> isNovember() {
+    public static DateMatcher<ZonedDateTime> isNovember() {
         return isMonth(NOVEMBER);
     }
 
@@ -852,7 +897,7 @@ public abstract class ZonedDateTimeMatchers {
      * assertThat(myDate, isDecember());
      * </pre>
      */
-    public static Matcher<ZonedDateTime> isDecember() {
+    public static DateMatcher<ZonedDateTime> isDecember() {
         return isMonth(DECEMBER);
     }
 
@@ -865,8 +910,11 @@ public abstract class ZonedDateTimeMatchers {
      * assertThat(myDate, isLeapYear());
      * </pre>
      */
-    public static Matcher<ZonedDateTime> isLeapYear() {
-        return new IsLeapYear<ZonedDateTime>(t -> t, new ZonedDateTimeFormatter());
+    public static DateMatcher<ZonedDateTime> isLeapYear() {
+        return new IsLeapYear<>(
+            (d, z) -> d.withZoneSameInstant(z),
+            new ZonedDateTimeFormatter()
+        );
     }
 
     /**
@@ -880,8 +928,11 @@ public abstract class ZonedDateTimeMatchers {
      *
      * @param hour the hour of the day (0-23)
      */
-    public static Matcher<ZonedDateTime> isHour(final int hour) {
-        return new IsHour<ZonedDateTime>(hour, t -> t);
+    public static DateMatcher<ZonedDateTime> isHour(final int hour) {
+        return new IsHour<>(
+            new FieldZonedDateTimeWrapper(hour, ChronoField.HOUR_OF_DAY),
+            (d, z) -> ZonedDateTime.ofInstant(d.toInstant(), z).get(ChronoField.HOUR_OF_DAY)
+        );
     }
 
     /**
@@ -895,8 +946,11 @@ public abstract class ZonedDateTimeMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<ZonedDateTime> sameHourOfDay(final ZonedDateTime date) {
-        return isHour(date.getHour());
+    public static DateMatcher<ZonedDateTime> sameHourOfDay(final ZonedDateTime date) {
+        return new IsHour<>(
+            new FieldZonedDateTimeWrapper(date, ChronoField.HOUR_OF_DAY),
+            (d, z) -> ZonedDateTime.ofInstant(d.toInstant(), z).get(ChronoField.HOUR_OF_DAY)
+        );
     }
 
     /**
@@ -908,10 +962,13 @@ public abstract class ZonedDateTimeMatchers {
      * assertThat(myDate, isMinute(12));
      * </pre>
      *
-     * @param Minute the minute of the day (0-59)
+     * @param minute the minute of the day (0-59)
      */
-    public static Matcher<ZonedDateTime> isMinute(final int minute) {
-        return new IsMinute<ZonedDateTime>(minute, t -> t);
+    public static DateMatcher<ZonedDateTime> isMinute(final int minute) {
+        return new IsMinute<>(
+            new FieldZonedDateTimeWrapper(minute, ChronoField.MINUTE_OF_HOUR),
+            (d, z) -> ZonedDateTime.ofInstant(d.toInstant(), z).get(ChronoField.MINUTE_OF_HOUR)
+        );
     }
 
     /**
@@ -925,8 +982,11 @@ public abstract class ZonedDateTimeMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<ZonedDateTime> sameMinuteOfHour(final ZonedDateTime date) {
-        return isMinute(date.getMinute());
+    public static DateMatcher<ZonedDateTime> sameMinuteOfHour(final ZonedDateTime date) {
+        return new IsMinute<>(
+            new FieldZonedDateTimeWrapper(date, ChronoField.MINUTE_OF_HOUR),
+            (d, z) -> ZonedDateTime.ofInstant(d.toInstant(), z).get(ChronoField.MINUTE_OF_HOUR)
+        );
     }
 
     /**
@@ -938,10 +998,13 @@ public abstract class ZonedDateTimeMatchers {
      * assertThat(myDate, isSecond(12));
      * </pre>
      *
-     * @param Second the second of the day (0-59)
+     * @param second the second of the day (0-59)
      */
-    public static Matcher<ZonedDateTime> isSecond(final int Second) {
-        return new IsSecond<ZonedDateTime>(Second, t -> t);
+    public static DateMatcher<ZonedDateTime> isSecond(final int second) {
+        return new IsSecond<>(
+            new FieldZonedDateTimeWrapper(second, ChronoField.SECOND_OF_MINUTE),
+            (d, z) -> ZonedDateTime.ofInstant(d.toInstant(), z).get(ChronoField.SECOND_OF_MINUTE)
+        );
     }
 
     /**
@@ -955,7 +1018,10 @@ public abstract class ZonedDateTimeMatchers {
      *
      * @param date the reference date against which the examined date is checked
      */
-    public static Matcher<ZonedDateTime> sameSecondOfMinute(final ZonedDateTime date) {
-        return isSecond(date.getSecond());
+    public static DateMatcher<ZonedDateTime> sameSecondOfMinute(final ZonedDateTime date) {
+        return new IsSecond<>(
+            new FieldZonedDateTimeWrapper(date, ChronoField.SECOND_OF_MINUTE),
+            (d, z) -> ZonedDateTime.ofInstant(d.toInstant(), z).get(ChronoField.SECOND_OF_MINUTE)
+        );
     }
 }

--- a/src/main/java/org/exparity/hamcrest/date/core/AnyOf.java
+++ b/src/main/java/org/exparity/hamcrest/date/core/AnyOf.java
@@ -1,0 +1,57 @@
+package org.exparity.hamcrest.date.core;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+
+import java.time.ZoneId;
+import java.util.function.BiFunction;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toList;
+
+/**
+ * A matcher that tests that the examined date matches at least one of the given matchers
+ *
+ * @author Thomas Naskali
+ */
+public class AnyOf<T> extends DateMatcher<T> {
+
+  private final Stream<DateMatcher<? super T>> dateMatchers;
+  private final ZoneId zone;
+  private final BiFunction<T, ZoneId, String> descriptionProvider;
+  private final org.hamcrest.core.AnyOf<? super T> anyOf;
+
+  private AnyOf(final Stream<DateMatcher<? super T>> dateMatchers, final ZoneId zone, final BiFunction<T, ZoneId, String> descriptionProvider) {
+    this.dateMatchers = dateMatchers;
+    this.zone = zone;
+    this.descriptionProvider = descriptionProvider;
+    this.anyOf = new org.hamcrest.core.AnyOf<>(
+        this.dateMatchers.map(m -> (Matcher<? super T>) m.atZone(zone)).collect(toList())
+    );
+  }
+
+  public AnyOf(final Stream<DateMatcher<? super T>> dateMatchers, final BiFunction<T, ZoneId, String> descriptionProvider) {
+    this(dateMatchers, ZoneId.systemDefault(), descriptionProvider);
+  }
+
+  @Override
+  protected boolean matchesSafely(final T t, final Description mismatchDescription) {
+    if (!anyOf.matches(t)) {
+      mismatchDescription.appendText(descriptionProvider.apply(t, zone));
+      return false;
+    } else {
+      return true;
+    }
+  }
+
+  @Override
+  public void describeTo(final Description description) {
+    anyOf.describeTo(description);
+  }
+
+  @Override
+  public DateMatcher<T> atZone(final ZoneId zone) {
+    return new AnyOf<>(dateMatchers, zone, descriptionProvider);
+  }
+
+}

--- a/src/main/java/org/exparity/hamcrest/date/core/DateMatcher.java
+++ b/src/main/java/org/exparity/hamcrest/date/core/DateMatcher.java
@@ -1,0 +1,24 @@
+package org.exparity.hamcrest.date.core;
+
+import java.time.ZoneId;
+
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+/**
+ * Abstract {@link org.hamcrest.Matcher<T>} for temporal objects allowing for time zone manipulation.
+ *
+ * @param <T> the type of objects handled by this matcher
+ *
+ * @author Thomas Naskali
+ */
+public abstract class DateMatcher<T> extends TypeSafeDiagnosingMatcher<T> {
+
+    /**
+     * Creates a copy of this matcher using a specific time zone.
+     *
+     * @param zone the new time zone
+     * @return a copy of this matcher based on the new time zone
+     */
+    public abstract DateMatcher<T> atZone(ZoneId zone);
+
+}

--- a/src/main/java/org/exparity/hamcrest/date/core/IsAfter.java
+++ b/src/main/java/org/exparity/hamcrest/date/core/IsAfter.java
@@ -1,14 +1,15 @@
 package org.exparity.hamcrest.date.core;
 
+import java.time.ZoneId;
+
 import org.hamcrest.Description;
-import org.hamcrest.TypeSafeDiagnosingMatcher;
 
 /**
  * A matcher that tests that the examined date is after the reference date
  *
  * @author Stewart Bissett
  */
-public class IsAfter<T> extends TypeSafeDiagnosingMatcher<T> {
+public class IsAfter<T> extends DateMatcher<T> {
 
 	private final TemporalWrapper<T> expected;
 	private final TemporalFormatter<T> describer;
@@ -32,4 +33,10 @@ public class IsAfter<T> extends TypeSafeDiagnosingMatcher<T> {
 	public void describeTo(final Description description) {
 		description.appendText("the date is after " + describer.describe(expected.unwrap()));
 	}
+
+	@Override
+	public DateMatcher<T> atZone(ZoneId zone) {
+		return new IsAfter<>(expected.withZone(zone), describer);
+	}
+
 }

--- a/src/main/java/org/exparity/hamcrest/date/core/IsBefore.java
+++ b/src/main/java/org/exparity/hamcrest/date/core/IsBefore.java
@@ -1,14 +1,15 @@
 package org.exparity.hamcrest.date.core;
 
+import java.time.ZoneId;
+
 import org.hamcrest.Description;
-import org.hamcrest.TypeSafeDiagnosingMatcher;
 
 /**
  * A matcher that tests that the examined date is before the reference date
  *
  * @author Stewart Bissett
  */
-public class IsBefore<T> extends TypeSafeDiagnosingMatcher<T> {
+public class IsBefore<T> extends DateMatcher<T> {
 
 	private final TemporalWrapper<T> expected;
 	private final TemporalFormatter<T> describer;
@@ -32,4 +33,10 @@ public class IsBefore<T> extends TypeSafeDiagnosingMatcher<T> {
 	public void describeTo(final Description description) {
 		description.appendText("the date is before " + this.describer.describe(this.expected.unwrap()));
 	}
+
+	@Override
+	public DateMatcher<T> atZone(ZoneId zone) {
+		return new IsBefore<>(expected.withZone(zone), describer);
+	}
+
 }

--- a/src/main/java/org/exparity/hamcrest/date/core/IsDayOfMonth.java
+++ b/src/main/java/org/exparity/hamcrest/date/core/IsDayOfMonth.java
@@ -1,38 +1,48 @@
 package org.exparity.hamcrest.date.core;
 
-import java.time.temporal.ChronoField;
+import java.time.ZoneId;
 
 import org.hamcrest.Description;
-import org.hamcrest.TypeSafeDiagnosingMatcher;
 
 /**
  * A matcher that tests that the examined date is on the specified hour
  *
  * @author Stewart Bissett
  */
-public class IsDayOfMonth<T> extends TypeSafeDiagnosingMatcher<T> {
+public class IsDayOfMonth<T> extends DateMatcher<T> {
 
-	private final int expected;
-	private final TemporalAdapter<T> adapter;
+	private final TemporalFieldWrapper<T> expected;
+	private final TemporalFieldAdapter<T> accessor;
+	private final ZoneId zone;
 
-	public IsDayOfMonth(final int expected, final TemporalAdapter<T> adapter) {
+	private IsDayOfMonth(final TemporalFieldWrapper<T> expected, final TemporalFieldAdapter<T> accessor, final ZoneId zone) {
 		this.expected = expected;
-		this.adapter = adapter;
+		this.accessor = accessor;
+		this.zone = zone;
+	}
+
+	public IsDayOfMonth(final TemporalFieldWrapper<T> expected, final TemporalFieldAdapter<T> accessor) {
+		this(expected, accessor, ZoneId.systemDefault());
 	}
 
 	@Override
 	protected boolean matchesSafely(final T actual, final Description mismatchDescription) {
-		int actualValue = this.adapter.asTemporal(actual).get(ChronoField.DAY_OF_MONTH);
-		if (this.expected == actualValue) {
-			return true;
-		} else {
-			mismatchDescription.appendText("the date is on the " + actualValue + " day of the month");
+		if (!this.expected.isSame(actual)) {
+			mismatchDescription.appendText("the date has the day of month " + accessor.asTemporalField(actual, zone));
 			return false;
+		} else {
+			return true;
 		}
 	}
 
 	@Override
 	public void describeTo(final Description description) {
-		description.appendText("the date is on the " + this.expected + " day of the month");
+		description.appendText("the date has the day of month " + expected.unwrap());
 	}
+
+	@Override
+	public DateMatcher<T> atZone(ZoneId zone) {
+		return new IsDayOfMonth<>(expected.withZone(zone), accessor);
+	}
+
 }

--- a/src/main/java/org/exparity/hamcrest/date/core/IsDayOfWeek.java
+++ b/src/main/java/org/exparity/hamcrest/date/core/IsDayOfWeek.java
@@ -1,61 +1,49 @@
 package org.exparity.hamcrest.date.core;
 
-import static java.util.Arrays.asList;
-
 import java.time.DayOfWeek;
-import java.time.temporal.ChronoField;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.time.ZoneId;
 
 import org.hamcrest.Description;
-import org.hamcrest.TypeSafeDiagnosingMatcher;
 
 /**
  * A matcher that tests that the examined date is on the same day of the week as the reference date
  *
  * @author Stewart Bissett
  */
-public class IsDayOfWeek<T> extends TypeSafeDiagnosingMatcher<T> {
+public class IsDayOfWeek<T> extends DateMatcher<T> {
 
-    private final Set<DayOfWeek> daysOfWeeks = new HashSet<>();
-    private final String description;
-    private final TemporalAdapter<T> accessor;
+    private final TemporalFieldWrapper<T> expected;
+    private final TemporalFieldAdapter<T> accessor;
+    private final ZoneId zone;
 
-    public IsDayOfWeek(final List<DayOfWeek> daysOfWeek, final TemporalAdapter<T> accessor) {
-        this.daysOfWeeks.addAll(daysOfWeek);
-        this.description = describeDaysOfWeek(daysOfWeek);
+    private IsDayOfWeek(final TemporalFieldWrapper<T> expected, final TemporalFieldAdapter<T> accessor, final ZoneId zone) {
+        this.expected = expected;
         this.accessor = accessor;
+        this.zone = zone;
     }
 
-    public IsDayOfWeek(final DayOfWeek dayOfWeek, final TemporalAdapter<T> accessor) {
-        this(asList(dayOfWeek), accessor);
+    public IsDayOfWeek(final TemporalFieldWrapper<T> expected, final TemporalFieldAdapter<T> accessor) {
+        this(expected, accessor, ZoneId.systemDefault());
     }
 
     @Override
-    protected boolean matchesSafely(final T actual, final Description mismatchDesc) {
-        DayOfWeek actualValue = DayOfWeek.of(this.accessor.asTemporal(actual).get(ChronoField.DAY_OF_WEEK));
-        if (this.daysOfWeeks.contains(actualValue)) {
-            return true;
-        } else {
-            mismatchDesc.appendText("the date is on a " + actualValue.name().toLowerCase());
+    protected boolean matchesSafely(final T actual, final Description mismatchDescription) {
+        if (!this.expected.isSame(actual)) {
+            mismatchDescription.appendText("the date is on a " + DayOfWeek.of(accessor.asTemporalField(actual, zone)).name().toLowerCase());
             return false;
+        } else {
+            return true;
         }
     }
 
     @Override
     public void describeTo(final Description description) {
-        description.appendText("the date is on a " + this.description);
+        description.appendText("the date is on a " + DayOfWeek.of(expected.unwrap()).name().toLowerCase());
     }
 
-    private String describeDaysOfWeek(final List<DayOfWeek> daysOfWeek) {
-        StringBuffer buffer = new StringBuffer();
-        String seperator = "";
-        for (int i = 0; i < daysOfWeek.size(); ++i) {
-            buffer.append(seperator).append(daysOfWeek.get(i).name().toLowerCase());
-            seperator = i == daysOfWeek.size() - 2 ? " or " : ", ";
-        }
-        return buffer.toString();
+    @Override
+    public DateMatcher<T> atZone(ZoneId zone) {
+        return new IsDayOfWeek<>(expected.withZone(zone), accessor);
     }
 
 }

--- a/src/main/java/org/exparity/hamcrest/date/core/IsHour.java
+++ b/src/main/java/org/exparity/hamcrest/date/core/IsHour.java
@@ -1,38 +1,48 @@
 package org.exparity.hamcrest.date.core;
 
-import java.time.temporal.ChronoField;
+import java.time.ZoneId;
 
 import org.hamcrest.Description;
-import org.hamcrest.TypeSafeDiagnosingMatcher;
 
 /**
  * A matcher that tests that the examined date is on the specified hour
  *
  * @author Stewart Bissett
  */
-public class IsHour<T> extends TypeSafeDiagnosingMatcher<T> {
+public class IsHour<T> extends DateMatcher<T> {
 
-	private final int expected;
-	private final TemporalAdapter<T> accessor;
+	private final TemporalFieldWrapper<T> expected;
+	private final TemporalFieldAdapter<T> accessor;
+	private final ZoneId zone;
 
-	public IsHour(final int expected, final TemporalAdapter<T> accessor) {
+	private IsHour(final TemporalFieldWrapper<T> expected, final TemporalFieldAdapter<T> accessor, final ZoneId zone) {
 		this.expected = expected;
 		this.accessor = accessor;
+		this.zone = zone;
+	}
+
+	public IsHour(final TemporalFieldWrapper<T> expected, final TemporalFieldAdapter<T> accessor) {
+		this(expected, accessor, ZoneId.systemDefault());
 	}
 
 	@Override
 	protected boolean matchesSafely(final T actual, final Description mismatchDescription) {
-		int actualHour = accessor.asTemporal(actual).get(ChronoField.HOUR_OF_DAY);
-		if (expected == actualHour) {
-			return true;
-		} else {
-			mismatchDescription.appendText("the date has the hour " + actualHour);
+		if (!this.expected.isSame(actual)) {
+			mismatchDescription.appendText("the date has the hour " + accessor.asTemporalField(actual, zone));
 			return false;
+		} else {
+			return true;
 		}
 	}
 
 	@Override
 	public void describeTo(final Description description) {
-		description.appendText("the date has the hour " + expected);
+		description.appendText("the date has the hour " + expected.unwrap());
 	}
+
+	@Override
+	public DateMatcher<T> atZone(ZoneId zone) {
+		return new IsHour<>(expected.withZone(zone), accessor);
+	}
+
 }

--- a/src/main/java/org/exparity/hamcrest/date/core/IsLeapYear.java
+++ b/src/main/java/org/exparity/hamcrest/date/core/IsLeapYear.java
@@ -2,27 +2,37 @@ package org.exparity.hamcrest.date.core;
 
 import static java.time.temporal.TemporalQueries.localDate;
 
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
 import org.hamcrest.Description;
-import org.hamcrest.TypeSafeDiagnosingMatcher;
 
 /**
  * A matcher that tests that the examined date is a leap year
  *
  * @author Stewart Bissett
  */
-public class IsLeapYear<T> extends TypeSafeDiagnosingMatcher<T> {
+public class IsLeapYear<T> extends DateMatcher<T> {
 
 	private final TemporalAdapter<T> adapter;
 	private final TemporalFormatter<T> formatter;
+	private final ZoneId zone;
+
+	private IsLeapYear(final TemporalAdapter<T> adapter, final TemporalFormatter<T> formatter, final ZoneId zone) {
+		this.adapter = adapter;
+		this.formatter = formatter;
+		this.zone = zone;
+	}
 
 	public IsLeapYear(final TemporalAdapter<T> adapter, final TemporalFormatter<T> formatter) {
 		this.adapter = adapter;
 		this.formatter = formatter;
+		this.zone = ZoneId.systemDefault();
 	}
 
 	@Override
 	protected boolean matchesSafely(final T actual, final Description mismatchDesc) {
-		if (!this.adapter.asTemporal(actual).query(localDate()).isLeapYear()) {
+		if (!this.adapter.asTemporal(actual, zone).query(localDate()).isLeapYear()) {
 			mismatchDesc.appendText("the date " + this.formatter.describe(actual) + " is not a leap year");
 			return false;
 		} else {
@@ -34,4 +44,10 @@ public class IsLeapYear<T> extends TypeSafeDiagnosingMatcher<T> {
 	public void describeTo(final Description description) {
 		description.appendText("a leap year");
 	}
+
+	@Override
+	public DateMatcher<T> atZone(ZoneId zone) {
+		return new IsLeapYear<>(adapter, formatter, zone);
+	}
+
 }

--- a/src/main/java/org/exparity/hamcrest/date/core/IsMaximum.java
+++ b/src/main/java/org/exparity/hamcrest/date/core/IsMaximum.java
@@ -1,43 +1,65 @@
 package org.exparity.hamcrest.date.core;
 
+import java.time.ZoneId;
 import java.time.temporal.ChronoField;
 import java.time.temporal.ValueRange;
 import java.util.function.Supplier;
 
 import org.exparity.hamcrest.date.core.format.DatePartFormatter;
 import org.hamcrest.Description;
-import org.hamcrest.TypeSafeDiagnosingMatcher;
 
 /**
  * A base matcher that tests that the examined date has the maximum value for the given date part
  *
  * @author Stewart Bissett
  */
-public class IsMaximum<T> extends TypeSafeDiagnosingMatcher<T> {
+public class IsMaximum<T> extends DateMatcher<T> {
 
     private final ChronoField datePart;
-    private final TemporalAdapter<T> adapter;
+    private final TemporalFieldAdapter<T> adapter;
+    private final TemporalFieldRangeAdapter<T> rangeAdapter;
     private final DatePartFormatter formatter;
     private final Supplier<String> descriptionSupplier;
+    private final ZoneId zone;
 
-    public IsMaximum(final ChronoField datePart,
-            final TemporalAdapter<T> adapter,
-            final DatePartFormatter formatter,
-            final Supplier<String> descriptionSupplier) {
+    private IsMaximum(final ChronoField datePart,
+                      final TemporalFieldAdapter<T> adapter,
+                      final TemporalFieldRangeAdapter<T> rangeAdapter,
+                      final DatePartFormatter formatter,
+                      final Supplier<String> descriptionSupplier,
+                      final ZoneId zone) {
         this.datePart = datePart;
         this.adapter = adapter;
+        this.rangeAdapter = rangeAdapter;
         this.formatter = formatter;
         this.descriptionSupplier = descriptionSupplier;
+        this.zone = zone;
     }
 
-    public IsMaximum(final ChronoField datePart, final TemporalAdapter<T> adapter, final DatePartFormatter formatter) {
-        this(datePart, adapter, formatter, () -> "the date is the maximum value for " + formatter.describe(datePart));
+    public IsMaximum(final ChronoField datePart,
+                     final TemporalFieldAdapter<T> adapter,
+                     final TemporalFieldRangeAdapter<T> rangeAdapter,
+                     final DatePartFormatter formatter,
+                     final Supplier<String> descriptionSupplier) {
+        this.datePart = datePart;
+        this.adapter = adapter;
+        this.rangeAdapter = rangeAdapter;
+        this.formatter = formatter;
+        this.descriptionSupplier = descriptionSupplier;
+        this.zone = ZoneId.systemDefault();
+    }
+
+    public IsMaximum(final ChronoField datePart,
+                     final TemporalFieldAdapter<T> adapter,
+                     final TemporalFieldRangeAdapter<T> rangeAdapter,
+                     final DatePartFormatter formatter) {
+        this(datePart, adapter, rangeAdapter, formatter, () -> "the date is the maximum value for " + formatter.describe(datePart));
     }
 
     @Override
     protected boolean matchesSafely(final T actual, final Description mismatchDesc) {
-        long actualValue = this.datePart.getFrom(this.adapter.asTemporal(actual));
-        ValueRange range = this.datePart.rangeRefinedBy(this.adapter.asTemporal(actual));
+        long actualValue = this.adapter.asTemporalField(actual, zone);
+        ValueRange range = this.rangeAdapter.asTemporalFieldRange(actual, zone);
         if (range.getMaximum() != actualValue) {
             mismatchDesc.appendText("date is the " + actualValue
                     + " "
@@ -56,4 +78,17 @@ public class IsMaximum<T> extends TypeSafeDiagnosingMatcher<T> {
     public void describeTo(final Description description) {
         description.appendText(this.descriptionSupplier.get());
     }
+
+    @Override
+   	public DateMatcher<T> atZone(ZoneId zone) {
+   		return new IsMaximum<>(
+   		    datePart,
+          adapter,
+          rangeAdapter,
+          formatter,
+          descriptionSupplier,
+          zone
+      );
+   	}
+
 }

--- a/src/main/java/org/exparity/hamcrest/date/core/IsMillisecond.java
+++ b/src/main/java/org/exparity/hamcrest/date/core/IsMillisecond.java
@@ -1,38 +1,48 @@
 package org.exparity.hamcrest.date.core;
 
-import java.time.temporal.ChronoField;
+import java.time.ZoneId;
 
 import org.hamcrest.Description;
-import org.hamcrest.TypeSafeDiagnosingMatcher;
 
 /**
  * A matcher that tests that the examined date is on the specified minute
  *
  * @author Stewart Bissett
  */
-public class IsMillisecond<T> extends TypeSafeDiagnosingMatcher<T> {
+public class IsMillisecond<T> extends DateMatcher<T> {
 
-	private final int expected;
-	private final TemporalAdapter<T> accessor;
+	private final TemporalFieldWrapper<T> expected;
+	private final TemporalFieldAdapter<T> accessor;
+	private final ZoneId zone;
 
-	public IsMillisecond(final int expected, final TemporalAdapter<T> accessor) {
+	private IsMillisecond(final TemporalFieldWrapper<T> expected, final TemporalFieldAdapter<T> accessor, final ZoneId zone) {
 		this.expected = expected;
 		this.accessor = accessor;
+		this.zone = zone;
+	}
+
+	public IsMillisecond(final TemporalFieldWrapper<T> expected, final TemporalFieldAdapter<T> accessor) {
+		this(expected, accessor, ZoneId.systemDefault());
 	}
 
 	@Override
 	protected boolean matchesSafely(final T actual, final Description mismatchDescription) {
-		int actualMillis = accessor.asTemporal(actual).get(ChronoField.MILLI_OF_SECOND);
-		if (expected == actualMillis) {
-			return true;
-		} else {
-			mismatchDescription.appendText("the date has the millisecond " + actualMillis);
+		if (!this.expected.isSame(actual)) {
+			mismatchDescription.appendText("the date has the millisecond " + accessor.asTemporalField(actual, zone));
 			return false;
+		} else {
+			return true;
 		}
 	}
 
 	@Override
 	public void describeTo(final Description description) {
-		description.appendText("the date has the millisecond " + expected);
+		description.appendText("the date has the millisecond " + expected.unwrap());
 	}
+
+	@Override
+	public DateMatcher<T> atZone(ZoneId zone) {
+		return new IsMillisecond<>(expected.withZone(zone), accessor);
+	}
+
 }

--- a/src/main/java/org/exparity/hamcrest/date/core/IsMinimum.java
+++ b/src/main/java/org/exparity/hamcrest/date/core/IsMinimum.java
@@ -1,43 +1,65 @@
 package org.exparity.hamcrest.date.core;
 
+import java.time.ZoneId;
 import java.time.temporal.ChronoField;
 import java.time.temporal.ValueRange;
 import java.util.function.Supplier;
 
 import org.exparity.hamcrest.date.core.format.DatePartFormatter;
 import org.hamcrest.Description;
-import org.hamcrest.TypeSafeDiagnosingMatcher;
 
 /**
  * A base matcher that tests that the examined date has the maximum value for the given date part
  *
  * @author Stewart Bissett
  */
-public class IsMinimum<T> extends TypeSafeDiagnosingMatcher<T> {
+public class IsMinimum<T> extends DateMatcher<T> {
 
     private final ChronoField datePart;
-    private final TemporalAdapter<T> adapter;
+    private final TemporalFieldAdapter<T> adapter;
+    private final TemporalFieldRangeAdapter<T> rangeAdapter;
     private final DatePartFormatter formatter;
     private final Supplier<String> descriptionSupplier;
+    private final ZoneId zone;
+
+    private IsMinimum(final ChronoField datePart,
+                      final TemporalFieldAdapter<T> adapter,
+                      final TemporalFieldRangeAdapter<T> rangeAdapter,
+                      final DatePartFormatter formatter,
+                      final Supplier<String> descriptionSupplier,
+                      final ZoneId zone) {
+        this.datePart = datePart;
+        this.adapter = adapter;
+        this.rangeAdapter = rangeAdapter;
+        this.formatter = formatter;
+        this.descriptionSupplier = descriptionSupplier;
+        this.zone = zone;
+    }
 
     public IsMinimum(final ChronoField datePart,
-            final TemporalAdapter<T> adapter,
+            final TemporalFieldAdapter<T> adapter,
+            final TemporalFieldRangeAdapter<T> rangeAdapter,
             final DatePartFormatter formatter,
             final Supplier<String> descriptionSupplier) {
         this.datePart = datePart;
         this.adapter = adapter;
+        this.rangeAdapter = rangeAdapter;
         this.formatter = formatter;
         this.descriptionSupplier = descriptionSupplier;
+        this.zone = ZoneId.systemDefault();
     }
 
-    public IsMinimum(final ChronoField datePart, final TemporalAdapter<T> adapter, final DatePartFormatter formatter) {
-        this(datePart, adapter, formatter, () -> "the date is the minimum value for " + formatter.describe(datePart));
+    public IsMinimum(final ChronoField datePart,
+                     final TemporalFieldAdapter<T> adapter,
+                     final TemporalFieldRangeAdapter<T> minimumAdapter,
+                     final DatePartFormatter formatter) {
+        this(datePart, adapter, minimumAdapter, formatter, () -> "the date is the minimum value for " + formatter.describe(datePart));
     }
 
     @Override
     protected boolean matchesSafely(final T actual, final Description mismatchDesc) {
-        long actualValue = this.datePart.getFrom(this.adapter.asTemporal(actual));
-        ValueRange range = this.datePart.rangeRefinedBy(this.adapter.asTemporal(actual));
+        int actualValue = this.adapter.asTemporalField(actual, zone);
+        ValueRange range = this.rangeAdapter.asTemporalFieldRange(actual, zone);
         if (range.getMinimum() != actualValue) {
             mismatchDesc.appendText("date is the " + actualValue
                     + " "
@@ -56,4 +78,16 @@ public class IsMinimum<T> extends TypeSafeDiagnosingMatcher<T> {
     public void describeTo(final Description description) {
         description.appendText(this.descriptionSupplier.get());
     }
+
+    @Override
+   	public DateMatcher<T> atZone(ZoneId zone) {
+   		return new IsMinimum<>(
+   		    datePart,
+          adapter,
+          rangeAdapter,
+          formatter,
+          descriptionSupplier,
+          zone);
+   	}
+
 }

--- a/src/main/java/org/exparity/hamcrest/date/core/IsMinute.java
+++ b/src/main/java/org/exparity/hamcrest/date/core/IsMinute.java
@@ -1,30 +1,34 @@
 package org.exparity.hamcrest.date.core;
 
-import java.time.temporal.ChronoField;
+import java.time.ZoneId;
 
 import org.hamcrest.Description;
-import org.hamcrest.TypeSafeDiagnosingMatcher;
 
 /**
  * A matcher that tests that the examined date is on the specified minute
  *
  * @author Stewart Bissett
  */
-public class IsMinute<T> extends TypeSafeDiagnosingMatcher<T> {
+public class IsMinute<T> extends DateMatcher<T> {
 
-	private final int expected;
-	private final TemporalAdapter<T> accessor;
+	private final TemporalFieldWrapper<T> expected;
+	private final TemporalFieldAdapter<T> accessor;
+	private final ZoneId zone;
 
-	public IsMinute(final int expected, final TemporalAdapter<T> accessor) {
+	private IsMinute(final TemporalFieldWrapper<T> expected, final TemporalFieldAdapter<T> accessor, final ZoneId zone) {
 		this.expected = expected;
 		this.accessor = accessor;
+		this.zone = zone;
+	}
+
+	public IsMinute(final TemporalFieldWrapper<T> expected, final TemporalFieldAdapter<T> accessor) {
+		this(expected, accessor, ZoneId.systemDefault());
 	}
 
 	@Override
 	protected boolean matchesSafely(final T actual, final Description mismatchDescription) {
-		int actualMinute = accessor.asTemporal(actual).get(ChronoField.MINUTE_OF_HOUR);
-		if (expected != actualMinute) {
-			mismatchDescription.appendText("the date has the minute " + actualMinute);
+		if (!this.expected.isSame(actual)) {
+			mismatchDescription.appendText("the date has the minute " + accessor.asTemporalField(actual, zone));
 			return false;
 		} else {
 			return true;
@@ -33,6 +37,12 @@ public class IsMinute<T> extends TypeSafeDiagnosingMatcher<T> {
 
 	@Override
 	public void describeTo(final Description description) {
-		description.appendText("the date has the minute " + expected);
+		description.appendText("the date has the minute " + expected.unwrap());
 	}
+
+	@Override
+	public DateMatcher<T> atZone(ZoneId zone) {
+		return new IsMinute<>(expected.withZone(zone), accessor);
+	}
+
 }

--- a/src/main/java/org/exparity/hamcrest/date/core/IsSame.java
+++ b/src/main/java/org/exparity/hamcrest/date/core/IsSame.java
@@ -1,14 +1,15 @@
 package org.exparity.hamcrest.date.core;
 
+import java.time.ZoneId;
+
 import org.hamcrest.Description;
-import org.hamcrest.TypeSafeDiagnosingMatcher;
 
 /**
  * A matcher that tests that the examined date is the same as the reference date
  *
  * @author Stewart Bissett
  */
-public class IsSame<T> extends TypeSafeDiagnosingMatcher<T> {
+public class IsSame<T> extends DateMatcher<T> {
 
 	private final TemporalWrapper<T> expected;
 	private final TemporalFormatter<T> describer;
@@ -32,4 +33,10 @@ public class IsSame<T> extends TypeSafeDiagnosingMatcher<T> {
 	public void describeTo(final Description description) {
 		description.appendText("the same date as " + this.describer.describe(this.expected.unwrap()));
 	}
+
+	@Override
+	public DateMatcher<T> atZone(ZoneId zone) {
+		return new IsSame<>(expected.withZone(zone), describer);
+	}
+
 }

--- a/src/main/java/org/exparity/hamcrest/date/core/IsSameDay.java
+++ b/src/main/java/org/exparity/hamcrest/date/core/IsSameDay.java
@@ -1,7 +1,8 @@
 package org.exparity.hamcrest.date.core;
 
+import java.time.ZoneId;
+
 import org.hamcrest.Description;
-import org.hamcrest.TypeSafeDiagnosingMatcher;
 
 /**
  * A matcher that tests that the examined date is the same date as the reference
@@ -9,7 +10,7 @@ import org.hamcrest.TypeSafeDiagnosingMatcher;
  *
  * @author Stewart Bissett
  */
-public class IsSameDay<T> extends TypeSafeDiagnosingMatcher<T> {
+public class IsSameDay<T> extends DateMatcher<T> {
 
 	private final TemporalWrapper<T> expected;
 	private final TemporalFormatter<T> describer;
@@ -21,7 +22,7 @@ public class IsSameDay<T> extends TypeSafeDiagnosingMatcher<T> {
 
 	@Override
 	protected boolean matchesSafely(final T actual, final Description mismatchDesc) {
-		if (!this.expected.isSameDay(actual)) {
+		if (!this.expected.isSame(actual)) {
 			mismatchDesc.appendText("the day is " + this.describer.describeDate(actual));
 			return false;
 		} else {
@@ -33,4 +34,10 @@ public class IsSameDay<T> extends TypeSafeDiagnosingMatcher<T> {
 	public void describeTo(final Description description) {
 		description.appendText("the same day as " + this.describer.describeDate(this.expected.unwrap()));
 	}
+
+	@Override
+	public DateMatcher<T> atZone(ZoneId zone) {
+		return new IsSameDay<>(expected.withZone(zone), describer);
+	}
+
 }

--- a/src/main/java/org/exparity/hamcrest/date/core/IsSameOrAfter.java
+++ b/src/main/java/org/exparity/hamcrest/date/core/IsSameOrAfter.java
@@ -1,7 +1,8 @@
 package org.exparity.hamcrest.date.core;
 
+import java.time.ZoneId;
+
 import org.hamcrest.Description;
-import org.hamcrest.TypeSafeDiagnosingMatcher;
 
 /**
  * A matcher that tests that the examined date is before or the same instant as
@@ -9,7 +10,7 @@ import org.hamcrest.TypeSafeDiagnosingMatcher;
  *
  * @author Stewart Bissett
  */
-public class IsSameOrAfter<T> extends TypeSafeDiagnosingMatcher<T> {
+public class IsSameOrAfter<T> extends DateMatcher<T> {
 
 	private final TemporalWrapper<T> expected;
 	private final TemporalFormatter<T> describer;
@@ -32,6 +33,11 @@ public class IsSameOrAfter<T> extends TypeSafeDiagnosingMatcher<T> {
 	@Override
 	public void describeTo(final Description description) {
 		description.appendText("the date is on the same date or after " + this.describer.describe(this.expected.unwrap()));
+	}
+
+	@Override
+	public DateMatcher<T> atZone(ZoneId zone) {
+		return new IsSameOrAfter<>(expected.withZone(zone), describer);
 	}
 
 }

--- a/src/main/java/org/exparity/hamcrest/date/core/IsSameOrBefore.java
+++ b/src/main/java/org/exparity/hamcrest/date/core/IsSameOrBefore.java
@@ -1,14 +1,15 @@
 package org.exparity.hamcrest.date.core;
 
+import java.time.ZoneId;
+
 import org.hamcrest.Description;
-import org.hamcrest.TypeSafeDiagnosingMatcher;
 
 /**
  * A matcher that tests that the actual date is before or the same instant as the reference date
  *
  * @author Stewart Bissett
  */
-public class IsSameOrBefore<T> extends TypeSafeDiagnosingMatcher<T> {
+public class IsSameOrBefore<T> extends DateMatcher<T> {
 
 	private final TemporalWrapper<T> expected;
 	private final TemporalFormatter<T> describer;
@@ -31,6 +32,11 @@ public class IsSameOrBefore<T> extends TypeSafeDiagnosingMatcher<T> {
 	@Override
 	public void describeTo(final Description description) {
 		description.appendText("the date is on the same date or before " + this.describer.describe(this.expected.unwrap()));
+	}
+
+	@Override
+	public DateMatcher<T> atZone(ZoneId zone) {
+		return new IsSameOrBefore<>(expected.withZone(zone), describer);
 	}
 
 }

--- a/src/main/java/org/exparity/hamcrest/date/core/IsSecond.java
+++ b/src/main/java/org/exparity/hamcrest/date/core/IsSecond.java
@@ -1,30 +1,34 @@
 package org.exparity.hamcrest.date.core;
 
-import java.time.temporal.ChronoField;
+import java.time.ZoneId;
 
 import org.hamcrest.Description;
-import org.hamcrest.TypeSafeDiagnosingMatcher;
 
 /**
  * A matcher that tests that the examined date is on the specified second
  *
  * @author Stewart Bissett
  */
-public class IsSecond<T> extends TypeSafeDiagnosingMatcher<T> {
+public class IsSecond<T> extends DateMatcher<T> {
 
-	private final int expected;
-	private final TemporalAdapter<T> accessor;
+	private final TemporalFieldWrapper<T> expected;
+	private final TemporalFieldAdapter<T> accessor;
+	private final ZoneId zone;
 
-	public IsSecond(final int expected, final TemporalAdapter<T> accessor) {
+	private IsSecond(final TemporalFieldWrapper<T> expected, final TemporalFieldAdapter<T> accessor, final ZoneId zone) {
 		this.expected = expected;
 		this.accessor = accessor;
+		this.zone = zone;
+	}
+
+	public IsSecond(final TemporalFieldWrapper<T> expected, final TemporalFieldAdapter<T> accessor) {
+		this(expected, accessor, ZoneId.systemDefault());
 	}
 
 	@Override
 	protected boolean matchesSafely(final T actual, final Description mismatchDescription) {
-		int actualSecond = accessor.asTemporal(actual).get(ChronoField.SECOND_OF_MINUTE);
-		if (expected != actualSecond) {
-			mismatchDescription.appendText("the date has the second " + actualSecond);
+		if (!this.expected.isSame(actual)) {
+			mismatchDescription.appendText("the date has the second " + accessor.asTemporalField(actual, zone));
 			return false;
 		} else {
 			return true;
@@ -33,6 +37,12 @@ public class IsSecond<T> extends TypeSafeDiagnosingMatcher<T> {
 
 	@Override
 	public void describeTo(final Description description) {
-		description.appendText("the date has the second " + expected);
+		description.appendText("the date has the second " + expected.unwrap());
 	}
+
+	@Override
+	public DateMatcher<T> atZone(ZoneId zone) {
+		return new IsSecond<>(expected.withZone(zone), accessor);
+	}
+
 }

--- a/src/main/java/org/exparity/hamcrest/date/core/IsWithin.java
+++ b/src/main/java/org/exparity/hamcrest/date/core/IsWithin.java
@@ -1,9 +1,9 @@
 package org.exparity.hamcrest.date.core;
 
+import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 
 import org.hamcrest.Description;
-import org.hamcrest.TypeSafeDiagnosingMatcher;
 
 /**
  * A matcher that tests that the examined date is within a defined period of the
@@ -11,7 +11,7 @@ import org.hamcrest.TypeSafeDiagnosingMatcher;
  *
  * @author Stewart Bissett
  */
-public class IsWithin<T> extends TypeSafeDiagnosingMatcher<T> {
+public class IsWithin<T> extends DateMatcher<T> {
 
 	private final long period;
 	private final ChronoUnit unit;
@@ -48,6 +48,11 @@ public class IsWithin<T> extends TypeSafeDiagnosingMatcher<T> {
 
 	private String describeUnit() {
 		return this.unit.toString().toLowerCase();
+	}
+
+	@Override
+	public DateMatcher<T> atZone(ZoneId zone) {
+		return new IsWithin<>(period, unit, expected.withZone(zone), describer);
 	}
 
 }

--- a/src/main/java/org/exparity/hamcrest/date/core/TemporalAdapter.java
+++ b/src/main/java/org/exparity/hamcrest/date/core/TemporalAdapter.java
@@ -1,8 +1,6 @@
-/**
- *
- */
 package org.exparity.hamcrest.date.core;
 
+import java.time.ZoneId;
 import java.time.temporal.Temporal;
 
 /**
@@ -16,7 +14,8 @@ public interface TemporalAdapter<T> {
 	/**
 	 * Return the value as a {@link Temporal}
 	 * @param source the source value to convert
+	 * @param zone the reference time zone
 	 * @return the value of the field
 	 */
-	public Temporal asTemporal(final T source);
+	Temporal asTemporal(final T source, final ZoneId zone);
 }

--- a/src/main/java/org/exparity/hamcrest/date/core/TemporalFieldAdapter.java
+++ b/src/main/java/org/exparity/hamcrest/date/core/TemporalFieldAdapter.java
@@ -1,0 +1,22 @@
+package org.exparity.hamcrest.date.core;
+
+import java.time.ZoneId;
+
+/**
+ * Adapter which can convert a value to a temporal field
+ *
+ * @see java.time.temporal.TemporalField
+ * @author Thomas Naskali
+ */
+@FunctionalInterface
+public interface TemporalFieldAdapter<T> {
+
+	/**
+	 * Return the value as a temporal field
+	 * @param source the source value to convert
+	 * @param zone the reference time zone
+	 * @return the value of the temporal field
+	 */
+	int asTemporalField(final T source, final ZoneId zone);
+
+}

--- a/src/main/java/org/exparity/hamcrest/date/core/TemporalFieldRangeAdapter.java
+++ b/src/main/java/org/exparity/hamcrest/date/core/TemporalFieldRangeAdapter.java
@@ -1,0 +1,22 @@
+package org.exparity.hamcrest.date.core;
+
+import java.time.ZoneId;
+import java.time.temporal.ValueRange;
+
+/**
+ * Adapter which can convert a value to a {@link ValueRange}
+ *
+ * @author Thomas Naskali
+ */
+@FunctionalInterface
+public interface TemporalFieldRangeAdapter<T> {
+
+	/**
+	 * Return the value as a {@link ValueRange}
+	 * @param source the source value to convert
+	 * @param zone the reference time zone
+	 * @return the value of the range
+	 */
+	ValueRange asTemporalFieldRange(final T source, final ZoneId zone);
+
+}

--- a/src/main/java/org/exparity/hamcrest/date/core/TemporalFieldWrapper.java
+++ b/src/main/java/org/exparity/hamcrest/date/core/TemporalFieldWrapper.java
@@ -1,0 +1,44 @@
+package org.exparity.hamcrest.date.core;
+
+import java.time.ZoneId;
+
+/**
+ * Wrapper which wraps a temporal field so it can support the operations required
+ * by the matchers
+ *
+ * @author Thomas Naskali
+ */
+public interface TemporalFieldWrapper<T> {
+
+	/**
+	 * @param other a temporal to test against
+	 * @return <code>true</code> if this temporal field is after the other
+	 */
+	boolean isAfter(final T other);
+
+    /**
+     * @param other a temporal to test against
+     * @return <code>true</code> if this temporal field is before the other
+     */
+    boolean isBefore(final T other);
+
+    /**
+     * @param other a temporal to test against
+     * @return <code>true</code> if this temporal field is the same as the other
+     */
+    boolean isSame(final T other);
+
+    /**
+     * @return a the wrapped value
+     */
+    int unwrap();
+
+	/**
+	 * Makes a copy of this wrapper based on a given time zone.
+	 *
+	 * @param zone a new reference time zone
+	 * @return a copy of the wrapper based on the new reference time zone
+	 */
+	TemporalFieldWrapper<T> withZone(ZoneId zone);
+
+}

--- a/src/main/java/org/exparity/hamcrest/date/core/TemporalFormatter.java
+++ b/src/main/java/org/exparity/hamcrest/date/core/TemporalFormatter.java
@@ -12,11 +12,11 @@ public interface TemporalFormatter<T> {
 	 * @param temporal the temporal value to describe
 	 * @return a pretty description of the temporal value as a date
 	 */
-	public String describe(T temporal);
+	String describe(T temporal);
 
 	/**
 	 * @param temporal the temporal value to describe
 	 * @return a pretty description of the date portion of the temporal
 	 */
-	public String describeDate(T unwrap);
+	String describeDate(T temporal);
 }

--- a/src/main/java/org/exparity/hamcrest/date/core/TemporalWrapper.java
+++ b/src/main/java/org/exparity/hamcrest/date/core/TemporalWrapper.java
@@ -1,8 +1,6 @@
-/**
- *
- */
 package org.exparity.hamcrest.date.core;
 
+import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 
 /**
@@ -17,34 +15,36 @@ public interface TemporalWrapper<T> {
 	 * @param other a temporal to test against
 	 * @return <code>true</code> if this temporal is after the other
 	 */
-	public boolean isAfter(final T other);
+	boolean isAfter(final T other);
 
 	/**
 	 * @param other a temporal to test against
-	 * @return <code>true</code> if this temporal is after the other
+	 * @return <code>true</code> if this temporal is before the other
 	 */
-	public boolean isBefore(final T other);
+	boolean isBefore(final T other);
 
 	/**
 	 * @param other a temporal to test against
-	 * @return <code>true</code> if this temporal is after the other
+	 * @return <code>true</code> if this temporal is the same as the other
 	 */
-	public boolean isSame(final T other);
-
-	/**
-	 * @param other a temporal to test against
-	 * @return <code>true</code> if this temporal is after the other
-	 */
-	public boolean isSameDay(final T other);
+	boolean isSame(final T other);
 
 	/**
 	 * @return a the wrapped value
 	 */
-	public T unwrap();
+	T unwrap();
 
 	/**
 	 * Return the difference in units between this time and the other time in the given units
 	 */
-	public long difference(final T other, final ChronoUnit unit);
+	long difference(final T other, final ChronoUnit unit);
+
+	/**
+	 * Makes a copy of this wrapper based on a given time zone.
+	 *
+	 * @param zone a new reference time zone
+	 * @return a copy of the wrapper based on the new reference time zone
+	 */
+	TemporalWrapper<T> withZone(ZoneId zone);
 
 }

--- a/src/main/java/org/exparity/hamcrest/date/core/format/DateFormatter.java
+++ b/src/main/java/org/exparity/hamcrest/date/core/format/DateFormatter.java
@@ -1,6 +1,3 @@
-/**
- *
- */
 package org.exparity.hamcrest.date.core.format;
 
 import java.text.SimpleDateFormat;

--- a/src/main/java/org/exparity/hamcrest/date/core/format/LocalDateFormatter.java
+++ b/src/main/java/org/exparity/hamcrest/date/core/format/LocalDateFormatter.java
@@ -1,6 +1,3 @@
-/**
- *
- */
 package org.exparity.hamcrest.date.core.format;
 
 import java.time.LocalDate;
@@ -16,8 +13,8 @@ import org.exparity.hamcrest.date.core.TemporalFormatter;
  */
 public class LocalDateFormatter implements TemporalFormatter<LocalDate> {
 
-	private static DateTimeFormatter DATE_TIME_FORMAT = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy");
-	private static DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy");
+	private static final DateTimeFormatter DATE_TIME_FORMAT = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy");
+	private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy");
 
 	@Override
 	public String describe(final LocalDate temporal) {

--- a/src/main/java/org/exparity/hamcrest/date/core/format/LocalDateTimeFormatter.java
+++ b/src/main/java/org/exparity/hamcrest/date/core/format/LocalDateTimeFormatter.java
@@ -1,6 +1,3 @@
-/**
- *
- */
 package org.exparity.hamcrest.date.core.format;
 
 import java.time.LocalDateTime;
@@ -16,8 +13,8 @@ import org.exparity.hamcrest.date.core.TemporalFormatter;
  */
 public class LocalDateTimeFormatter implements TemporalFormatter<LocalDateTime> {
 
-	private static DateTimeFormatter DATE_TIME_FORMAT = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy hh:mm:ss.SSS a");
-	private static DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy");
+	private static final DateTimeFormatter DATE_TIME_FORMAT = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy hh:mm:ss.SSS a");
+	private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy");
 
 	@Override
 	public String describe(final LocalDateTime temporal) {

--- a/src/main/java/org/exparity/hamcrest/date/core/format/LocalTimeFormatter.java
+++ b/src/main/java/org/exparity/hamcrest/date/core/format/LocalTimeFormatter.java
@@ -1,6 +1,3 @@
-/**
- *
- */
 package org.exparity.hamcrest.date.core.format;
 
 import java.time.LocalTime;
@@ -16,7 +13,7 @@ import org.exparity.hamcrest.date.core.TemporalFormatter;
  */
 public class LocalTimeFormatter implements TemporalFormatter<LocalTime> {
 
-	private static DateTimeFormatter DATE_TIME_FORMAT = DateTimeFormatter.ofPattern("hh:mm:ss a");
+	private static final DateTimeFormatter DATE_TIME_FORMAT = DateTimeFormatter.ofPattern("hh:mm:ss a");
 
 	@Override
 	public String describe(final LocalTime temporal) {

--- a/src/main/java/org/exparity/hamcrest/date/core/format/ZonedDateTimeFormatter.java
+++ b/src/main/java/org/exparity/hamcrest/date/core/format/ZonedDateTimeFormatter.java
@@ -1,6 +1,3 @@
-/**
- *
- */
 package org.exparity.hamcrest.date.core.format;
 
 import java.time.ZonedDateTime;
@@ -16,8 +13,8 @@ import org.exparity.hamcrest.date.core.TemporalFormatter;
  */
 public class ZonedDateTimeFormatter implements TemporalFormatter<ZonedDateTime> {
 
-	private static DateTimeFormatter DATE_TIME_FORMAT = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy hh:mm:ss.SSS a Z");
-	private static DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy");
+	private static final DateTimeFormatter DATE_TIME_FORMAT = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy hh:mm:ss.SSS a Z");
+	private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy");
 
 	@Override
 	public String describe(final ZonedDateTime temporal) {

--- a/src/main/java/org/exparity/hamcrest/date/core/wrapper/FieldDateWrapper.java
+++ b/src/main/java/org/exparity/hamcrest/date/core/wrapper/FieldDateWrapper.java
@@ -1,0 +1,64 @@
+package org.exparity.hamcrest.date.core.wrapper;
+
+import java.time.ZoneId;
+import java.time.temporal.ChronoField;
+import java.util.Date;
+import java.util.function.ToIntFunction;
+
+import org.exparity.hamcrest.date.core.TemporalFieldWrapper;
+
+/**
+ * Implementation of {@link TemporalFieldWrapper} which wraps a temporal field of a {@link Date} instance.
+ *
+ * @author Thomas Naskali
+ */
+public class FieldDateWrapper implements TemporalFieldWrapper<Date> {
+
+  private final ToIntFunction<ZoneId> wrapped;
+  private final ChronoField field;
+  private final ZoneId zone;
+
+  private FieldDateWrapper(final ToIntFunction<ZoneId> wrapped, final ChronoField field, final ZoneId zone) {
+    this.wrapped = wrapped;
+    this.field = field;
+    this.zone = zone;
+  }
+
+  public FieldDateWrapper(final int value, final ChronoField field) {
+    this.wrapped = (ignored) -> value;
+    this.field = field;
+    this.zone = ZoneId.systemDefault();
+  }
+
+  public FieldDateWrapper(Date date, ChronoField field) {
+    this.wrapped = z -> date.toInstant().atZone(z).get(field);
+    this.field = field;
+    this.zone = ZoneId.systemDefault();
+  }
+
+  @Override
+  public boolean isAfter(Date other) {
+    return wrapped.applyAsInt(zone) > other.toInstant().atZone(zone).get(field);
+  }
+
+  @Override
+  public boolean isBefore(Date other) {
+    return wrapped.applyAsInt(zone) < other.toInstant().atZone(zone).get(field);
+  }
+
+  @Override
+  public boolean isSame(Date other) {
+    return wrapped.applyAsInt(zone) == other.toInstant().atZone(zone).get(field);
+  }
+
+  @Override
+  public int unwrap() {
+    return wrapped.applyAsInt(zone);
+  }
+
+  @Override
+  public TemporalFieldWrapper<Date> withZone(ZoneId zone) {
+    return new FieldDateWrapper(wrapped, field, zone);
+  }
+
+}

--- a/src/main/java/org/exparity/hamcrest/date/core/wrapper/FieldLocalDateTimeWrapper.java
+++ b/src/main/java/org/exparity/hamcrest/date/core/wrapper/FieldLocalDateTimeWrapper.java
@@ -1,0 +1,64 @@
+package org.exparity.hamcrest.date.core.wrapper;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.temporal.ChronoField;
+import java.util.function.ToIntFunction;
+
+import org.exparity.hamcrest.date.core.TemporalFieldWrapper;
+
+/**
+ * Implementation of {@link TemporalFieldWrapper} which wraps a temporal field of a {@link LocalDateTime} instance.
+ *
+ * @author Thomas Naskali
+ */
+public class FieldLocalDateTimeWrapper implements TemporalFieldWrapper<LocalDateTime> {
+
+	private final ToIntFunction<ZoneId> wrapped;
+	private final ChronoField field;
+	private final ZoneId zone;
+
+	private FieldLocalDateTimeWrapper(final ToIntFunction<ZoneId> wrapped, final ChronoField field, final ZoneId zone) {
+		this.wrapped = wrapped;
+		this.field = field;
+		this.zone = zone;
+	}
+
+	public FieldLocalDateTimeWrapper(final int value, final ChronoField field) {
+		this.wrapped = (ignored) -> value;
+		this.field = field;
+		this.zone = ZoneId.systemDefault();
+	}
+
+	public FieldLocalDateTimeWrapper(final LocalDateTime date, final ChronoField field) {
+		this.wrapped = z -> date.atZone(z).get(field);
+		this.field = field;
+		this.zone = ZoneId.systemDefault();
+	}
+
+	@Override
+	public boolean isAfter(final LocalDateTime other) {
+		return wrapped.applyAsInt(zone) > other.atZone(zone).get(field);
+	}
+
+	@Override
+	public boolean isBefore(final LocalDateTime other) {
+		return wrapped.applyAsInt(zone) < other.atZone(zone).get(field);
+	}
+
+	@Override
+	public boolean isSame(final LocalDateTime other) {
+		return wrapped.applyAsInt(zone) == other.atZone(zone).get(field);
+	}
+
+	@Override
+	public int unwrap() {
+		return wrapped.applyAsInt(zone);
+	}
+
+	@Override
+	public TemporalFieldWrapper<LocalDateTime> withZone(final ZoneId zone) {
+		return new FieldLocalDateTimeWrapper(wrapped, field, zone);
+	}
+
+}

--- a/src/main/java/org/exparity/hamcrest/date/core/wrapper/FieldLocalDateWrapper.java
+++ b/src/main/java/org/exparity/hamcrest/date/core/wrapper/FieldLocalDateWrapper.java
@@ -1,0 +1,64 @@
+package org.exparity.hamcrest.date.core.wrapper;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.temporal.ChronoField;
+import java.util.function.ToIntFunction;
+
+import org.exparity.hamcrest.date.core.TemporalFieldWrapper;
+
+/**
+ * Implementation of {@link TemporalFieldWrapper} which wraps a temporal field of a {@link LocalDate} instance.
+ *
+ * @author Thomas Naskali
+ */
+public class FieldLocalDateWrapper implements TemporalFieldWrapper<LocalDate> {
+
+  private final ToIntFunction<ZoneId> wrapped;
+  private final ChronoField field;
+  private final ZoneId zone;
+
+  private FieldLocalDateWrapper(final ToIntFunction<ZoneId> wrapped, final ChronoField field, final ZoneId zone) {
+    this.wrapped = wrapped;
+    this.field = field;
+    this.zone = zone;
+  }
+
+  public FieldLocalDateWrapper(final int value, final ChronoField field) {
+    this.wrapped = (ignored) -> value;
+    this.field = field;
+    this.zone = ZoneId.systemDefault();
+  }
+
+  public FieldLocalDateWrapper(final LocalDate date, final ChronoField field) {
+    this.wrapped = z -> date.atStartOfDay(z).get(field);
+    this.field = field;
+    this.zone = ZoneId.systemDefault();
+  }
+
+  @Override
+  public boolean isAfter(final LocalDate other) {
+    return wrapped.applyAsInt(zone) > other.atStartOfDay(zone).get(field);
+  }
+
+  @Override
+  public boolean isBefore(final LocalDate other) {
+    return wrapped.applyAsInt(zone) < other.atStartOfDay(zone).get(field);
+  }
+
+  @Override
+  public boolean isSame(final LocalDate other) {
+    return wrapped.applyAsInt(zone) == other.atStartOfDay(zone).get(field);
+  }
+
+  @Override
+  public int unwrap() {
+    return wrapped.applyAsInt(zone);
+  }
+
+  @Override
+  public TemporalFieldWrapper<LocalDate> withZone(final ZoneId zone) {
+    return new FieldLocalDateWrapper(wrapped, field, zone);
+  }
+
+}

--- a/src/main/java/org/exparity/hamcrest/date/core/wrapper/FieldLocalTimeWrapper.java
+++ b/src/main/java/org/exparity/hamcrest/date/core/wrapper/FieldLocalTimeWrapper.java
@@ -1,0 +1,64 @@
+package org.exparity.hamcrest.date.core.wrapper;
+
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.temporal.ChronoField;
+import java.util.function.ToIntFunction;
+
+import org.exparity.hamcrest.date.core.TemporalFieldWrapper;
+
+/**
+ * Implementation of {@link TemporalFieldWrapper} which wraps a temporal field of a {@link LocalTime} instance.
+ *
+ * @author Thomas Naskali
+ */
+public class FieldLocalTimeWrapper implements TemporalFieldWrapper<LocalTime> {
+
+  private final ToIntFunction<ZoneId> wrapped;
+  private final ChronoField field;
+  private final ZoneId zone;
+
+  private FieldLocalTimeWrapper(final ToIntFunction<ZoneId> wrapped, final ChronoField field, final ZoneId zone) {
+    this.wrapped = wrapped;
+    this.field = field;
+    this.zone = zone;
+  }
+
+  public FieldLocalTimeWrapper(final int value, final ChronoField field) {
+    this.wrapped = (ignored) -> value;
+    this.field = field;
+    this.zone = ZoneId.systemDefault();
+  }
+
+  public FieldLocalTimeWrapper(final LocalTime date, final ChronoField field) {
+    this.wrapped = (ignored) -> date.get(field);
+    this.field = field;
+    this.zone = ZoneId.systemDefault();
+  }
+
+  @Override
+  public boolean isAfter(final LocalTime other) {
+    return wrapped.applyAsInt(zone) > other.get(field);
+  }
+
+  @Override
+  public boolean isBefore(final LocalTime other) {
+    return wrapped.applyAsInt(zone) < other.get(field);
+  }
+
+  @Override
+  public boolean isSame(final LocalTime other) {
+    return wrapped.applyAsInt(zone) == other.get(field);
+  }
+
+  @Override
+  public int unwrap() {
+    return wrapped.applyAsInt(zone);
+  }
+
+  @Override
+  public TemporalFieldWrapper<LocalTime> withZone(final ZoneId zone) {
+    return new FieldLocalTimeWrapper(wrapped, field, zone);
+  }
+
+}

--- a/src/main/java/org/exparity/hamcrest/date/core/wrapper/FieldZonedDateTimeWrapper.java
+++ b/src/main/java/org/exparity/hamcrest/date/core/wrapper/FieldZonedDateTimeWrapper.java
@@ -1,0 +1,64 @@
+package org.exparity.hamcrest.date.core.wrapper;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoField;
+import java.util.function.ToIntFunction;
+
+import org.exparity.hamcrest.date.core.TemporalFieldWrapper;
+
+/**
+ * Implementation of {@link TemporalFieldWrapper} which wraps a temporal field of a {@link ZonedDateTime} instance.
+ *
+ * @author Thomas Naskali
+ */
+public class FieldZonedDateTimeWrapper implements TemporalFieldWrapper<ZonedDateTime> {
+
+  private final ToIntFunction<ZoneId> wrapped;
+  private final ChronoField field;
+  private final ZoneId zone;
+
+  private FieldZonedDateTimeWrapper(final ToIntFunction<ZoneId> wrapped, final ChronoField field, final ZoneId zone) {
+    this.wrapped = wrapped;
+    this.field = field;
+    this.zone = zone;
+  }
+
+  public FieldZonedDateTimeWrapper(final int value, final ChronoField field) {
+    this.wrapped = (ignored) -> value;
+    this.field = field;
+    this.zone = ZoneId.systemDefault();
+  }
+
+  public FieldZonedDateTimeWrapper(final ZonedDateTime date, final ChronoField field) {
+    this.wrapped = z -> date.withZoneSameInstant(z).get(field);
+    this.field = field;
+    this.zone = ZoneId.systemDefault();
+  }
+
+  @Override
+  public boolean isAfter(final ZonedDateTime other) {
+    return wrapped.applyAsInt(zone) > other.withZoneSameInstant(zone).get(field);
+  }
+
+  @Override
+  public boolean isBefore(final ZonedDateTime other) {
+    return wrapped.applyAsInt(zone) < other.withZoneSameInstant(zone).get(field);
+  }
+
+  @Override
+  public boolean isSame(final ZonedDateTime other) {
+    return wrapped.applyAsInt(zone) == other.withZoneSameInstant(zone).get(field);
+  }
+
+  @Override
+  public int unwrap() {
+    return wrapped.applyAsInt(zone);
+  }
+
+  @Override
+  public TemporalFieldWrapper<ZonedDateTime> withZone(final ZoneId zone) {
+    return new FieldZonedDateTimeWrapper(wrapped, field, zone);
+  }
+
+}

--- a/src/main/java/org/exparity/hamcrest/date/core/wrapper/LocalDateTimeWrapper.java
+++ b/src/main/java/org/exparity/hamcrest/date/core/wrapper/LocalDateTimeWrapper.java
@@ -2,12 +2,12 @@ package org.exparity.hamcrest.date.core.wrapper;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.time.Month;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalUnit;
 import java.util.Date;
+import java.util.function.Supplier;
 
 import org.exparity.hamcrest.date.core.TemporalWrapper;
 
@@ -19,63 +19,82 @@ import org.exparity.hamcrest.date.core.TemporalWrapper;
  */
 public class LocalDateTimeWrapper implements TemporalWrapper<LocalDateTime> {
 
-	private final LocalDateTime wrapped;
+	private final Supplier<LocalDateTime> wrapped;
+	private final ZoneId zone;
 	private final TemporalUnit accuracy;
 
+	private LocalDateTimeWrapper(final Supplier<LocalDateTime> wrapped, final ZoneId zone, final TemporalUnit accuracy) {
+		this.wrapped = wrapped;
+		this.zone = zone;
+		this.accuracy = accuracy;
+	}
+
 	public LocalDateTimeWrapper(final Date date) {
-		wrapped = date.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime();
-		accuracy = ChronoUnit.MILLIS;
+		this(date, ChronoUnit.MILLIS);
+	}
+
+	public LocalDateTimeWrapper(final Date date, final TemporalUnit accuracy) {
+		this.zone = ZoneId.systemDefault();
+		this.wrapped = () -> date.toInstant().atZone(zone).toLocalDateTime();
+		this.accuracy = accuracy;
 	}
 
 	public LocalDateTimeWrapper(final LocalDateTime date) {
-		wrapped = date;
-		accuracy = ChronoUnit.NANOS;
+		this(date, ChronoUnit.NANOS);
+	}
+
+	public LocalDateTimeWrapper(final LocalDateTime date, final TemporalUnit accuracy) {
+		this.zone = ZoneId.systemDefault();
+		this.wrapped = () -> date;
+		this.accuracy = accuracy;
 	}
 
 	public LocalDateTimeWrapper(final int year, final Month month, final int dayOfMonth) {
-		wrapped = LocalDateTime.of(LocalDate.of(year, month, dayOfMonth), LocalTime.NOON);
-		accuracy = ChronoUnit.DAYS;
+		this.zone = ZoneId.systemDefault();
+		this.wrapped = () -> LocalDate.of(year, month, dayOfMonth).atStartOfDay();
+		this.accuracy = ChronoUnit.DAYS;
 	}
 
 	public LocalDateTimeWrapper(final int year, final Month month, final int dayOfMonth, final int hour, final int minute, final int second) {
-		wrapped = LocalDateTime.of(year, month, dayOfMonth, hour, minute, second);
-		accuracy = ChronoUnit.SECONDS;
+		this.zone = ZoneId.systemDefault();
+		this.wrapped = () -> LocalDateTime.of(year, month, dayOfMonth, hour, minute, second);
+		this.accuracy = ChronoUnit.SECONDS;
 	}
 
 	public LocalDateTimeWrapper(final int year, final Month month, final int dayOfMonth, final int hour, final int minute, final int second, final int nanos) {
-		wrapped = LocalDateTime.of(year, month, dayOfMonth, hour, minute, second, nanos);
-		accuracy = ChronoUnit.NANOS;
+		this.zone = ZoneId.systemDefault();
+		this.wrapped = () -> LocalDateTime.of(year, month, dayOfMonth, hour, minute, second, nanos);
+		this.accuracy = ChronoUnit.NANOS;
 	}
-
 
 	@Override
 	public long difference(final LocalDateTime other, final ChronoUnit unit) {
-		return Math.abs(wrapped.truncatedTo(accuracy).until(other, unit));
+		return Math.abs(wrapped.get().truncatedTo(accuracy).until(other, unit));
 	}
 
 	@Override
 	public boolean isAfter(final LocalDateTime other) {
-		return wrapped.truncatedTo(accuracy).isAfter(other.truncatedTo(accuracy));
+		return wrapped.get().truncatedTo(accuracy).isAfter(other.truncatedTo(accuracy));
 	}
 
 	@Override
 	public boolean isBefore(final LocalDateTime other) {
-		return wrapped.truncatedTo(accuracy).isBefore(other.truncatedTo(accuracy));
+		return wrapped.get().truncatedTo(accuracy).isBefore(other.truncatedTo(accuracy));
 	}
 
 	@Override
 	public boolean isSame(final LocalDateTime other) {
-		return wrapped.truncatedTo(accuracy).isEqual(other.truncatedTo(accuracy));
-	}
-
-	@Override
-	public boolean isSameDay(final LocalDateTime other) {
-		return wrapped.truncatedTo(ChronoUnit.DAYS).isEqual(other.truncatedTo(ChronoUnit.DAYS));
+		return wrapped.get().truncatedTo(accuracy).isEqual(other.truncatedTo(accuracy));
 	}
 
 	@Override
 	public LocalDateTime unwrap() {
-		return wrapped;
+		return wrapped.get();
+	}
+
+	@Override
+	public LocalDateTimeWrapper withZone(final ZoneId zone) {
+		return new LocalDateTimeWrapper(wrapped, zone, accuracy);
 	}
 
 }

--- a/src/main/java/org/exparity/hamcrest/date/core/wrapper/LocalDateWrapper.java
+++ b/src/main/java/org/exparity/hamcrest/date/core/wrapper/LocalDateWrapper.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
+import java.util.function.Supplier;
 
 import org.exparity.hamcrest.date.core.TemporalWrapper;
 
@@ -15,49 +16,58 @@ import org.exparity.hamcrest.date.core.TemporalWrapper;
  */
 public class LocalDateWrapper implements TemporalWrapper<LocalDate> {
 
-	private final LocalDate wrapped;
+	private final Supplier<LocalDate> wrapped;
+	private final ZoneId zone;
+
+	private LocalDateWrapper(final Supplier<LocalDate> wrapped, final ZoneId zone) {
+		this.wrapped = wrapped;
+		this.zone = zone;
+	}
 
 	public LocalDateWrapper(final Date date) {
-		this.wrapped = date.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+		this.zone = ZoneId.systemDefault();
+		this.wrapped = () -> date.toInstant().atZone(zone).toLocalDate();
 	}
 
 	public LocalDateWrapper(final LocalDate date) {
-		this.wrapped = date;
+		this.zone = ZoneId.systemDefault();
+		this.wrapped = () -> date;
 	}
 
 	@Override
-	public long difference(LocalDate other, ChronoUnit unit) {
-		return Math.abs(wrapped.until(other, unit));
+	public long difference(final LocalDate other, ChronoUnit unit) {
+		return Math.abs(wrapped.get().until(other, unit));
 	}
 
 	@Override
-	public boolean isAfter(LocalDate other) {
-		return wrapped.isAfter(other);
+	public boolean isAfter(final LocalDate other) {
+		return wrapped.get().isAfter(other);
 	}
 
 	@Override
-	public boolean isBefore(LocalDate other) {
-		return wrapped.isBefore(other);
+	public boolean isBefore(final LocalDate other) {
+		return wrapped.get().isBefore(other);
 	}
 
 	@Override
-	public boolean isSame(LocalDate other) {
-		return wrapped.isEqual(other);
+	public boolean isSame(final LocalDate other) {
+		return wrapped.get().isEqual(other);
 	}
 
-	@Override
-	public boolean isSameDay(LocalDate other) {
-		return wrapped.isEqual(other);
-	}
 
 	@Override
 	public LocalDate unwrap() {
-		return wrapped;
+		return wrapped.get();
 	}
 
 	@Override
 	public String toString() {
-		return wrapped.toString();
+		return wrapped.get().toString();
+	}
+
+	@Override
+	public TemporalWrapper<LocalDate> withZone(final ZoneId zone) {
+		return new LocalDateWrapper(this.wrapped, zone);
 	}
 
 }

--- a/src/main/java/org/exparity/hamcrest/date/core/wrapper/LocalTimeWrapper.java
+++ b/src/main/java/org/exparity/hamcrest/date/core/wrapper/LocalTimeWrapper.java
@@ -1,6 +1,7 @@
 package org.exparity.hamcrest.date.core.wrapper;
 
 import java.time.LocalTime;
+import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 
 import org.exparity.hamcrest.date.core.TemporalWrapper;
@@ -16,11 +17,11 @@ public class LocalTimeWrapper implements TemporalWrapper<LocalTime> {
 	private final LocalTime wrapped;
 
 	public LocalTimeWrapper(final LocalTime date) {
-		wrapped = date;
+		this.wrapped = date;
 	}
 
 	public LocalTimeWrapper(final int hour, final int minute, final int second) {
-		wrapped = LocalTime.of(hour, minute, second);
+		this(LocalTime.of(hour, minute, second));
 	}
 
 	@Override
@@ -44,13 +45,13 @@ public class LocalTimeWrapper implements TemporalWrapper<LocalTime> {
 	}
 
 	@Override
-	public boolean isSameDay(final LocalTime other) {
-		throw new UnsupportedOperationException("IsSameDay comparison is invalid on LocalTime");
+	public LocalTime unwrap() {
+		return wrapped;
 	}
 
 	@Override
-	public LocalTime unwrap() {
-		return wrapped;
+	public TemporalWrapper<LocalTime> withZone(final ZoneId zone) {
+		return this;
 	}
 
 }

--- a/src/test/java/org/exparity/hamcrest/date/core/IsAfterTest.java
+++ b/src/test/java/org/exparity/hamcrest/date/core/IsAfterTest.java
@@ -2,6 +2,7 @@ package org.exparity.hamcrest.date.core;
 
 import static java.time.Month.AUGUST;
 import static org.exparity.hamcrest.date.testutils.Dates.*;
+import static org.exparity.hamcrest.date.testutils.ZoneIds.UTC;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.time.LocalTime;
@@ -25,108 +26,108 @@ import org.testng.annotations.Test;
 @SuppressWarnings("deprecation")
 public class IsAfterTest {
 
-    private static final String ASSERTION_PATTERN = "\\s*Expected: the date is after [A-Za-z0-9:,.+ \\-]*\\s*but: date is [A-Za-z0-9:,.+ \\-]*";
+    private static final String ASSERTION_PATTERN = "\\sExpected: the date is after (?s:.)+?\\s     but: date is (?s:.)+";
 
 	// Date Matchers
 
 	@Test
 	public void isDateAfterEarlierDate() {
-		assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.after(JUN_15_2012_11AM_AS_DATE));
+		assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.after(JUN_15_2012_11AM_UTC_AS_DATE).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateAfterLaterDate() {
-		assertThat(JUN_15_2012_11AM_AS_DATE, DateMatchers.after(JUN_15_2012_11PM_AS_DATE));
+		assertThat(JUN_15_2012_11AM_UTC_AS_DATE, DateMatchers.after(JUN_15_2012_11PM_UTC_AS_DATE).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateAfterSameDate() {
-		assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.after(JUN_15_2012_11PM_AS_DATE));
+		assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.after(JUN_15_2012_11PM_UTC_AS_DATE).atZone(UTC));
 	}
 
 	@Test
 	public void isDateAfterSameDateDifferentTimeZone() {
-		assertThat(JAN_01_2012_11AM_PST_AS_DATE, DateMatchers.after(JAN_01_2012_11AM_GMT_AS_DATE));
+		assertThat(JAN_01_2012_11AM_PST_AS_DATE, DateMatchers.after(JAN_01_2012_11AM_GMT_AS_DATE).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateAfterLaterSameDateDifferentTimeZone() {
-		assertThat(JAN_01_2012_11AM_GMT_AS_DATE, DateMatchers.after(JAN_01_2012_11AM_PST_AS_DATE));
+		assertThat(JAN_01_2012_11AM_GMT_AS_DATE, DateMatchers.after(JAN_01_2012_11AM_PST_AS_DATE).atZone(UTC));
 	}
 
 	@Test
 	public void isDateAfterEarlierLocalDate() {
-		assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.after(JUN_14_2012));
+		assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.after(JUN_14_2012).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateAfterLaterLocalDate() {
-		assertThat(JUN_15_2012_11AM_AS_DATE, DateMatchers.after(JUN_16_2012));
+		assertThat(JUN_15_2012_11AM_UTC_AS_DATE, DateMatchers.after(JUN_16_2012).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateAfterSameLocalDate() {
-		assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.after(JUN_15_2012));
+		assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.after(JUN_15_2012).atZone(UTC));
 	}
 
 	@Test
 	public void isDateAfterEarlierDeprecatedDateValues() {
-		assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.after(2012, Months.JUNE, 14));
+		assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.after(2012, Months.JUNE, 14).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateAfterLaterDeprecatedDateValues() {
-		assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.after(2012, Months.JUNE, 16));
+		assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.after(2012, Months.JUNE, 16).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateAfterSameDeprecatedDateValues() {
-		assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.after(2012, Months.JUNE, 15));
+		assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.after(2012, Months.JUNE, 15).atZone(UTC));
 	}
 
 	@Test
 	public void isDateAfterEarlierDateValues() {
-		assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.after(2012, Month.JUNE, 14));
+		assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.after(2012, Month.JUNE, 14).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateAfterLaterDateValues() {
-		assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.after(2012, Month.JUNE, 16));
+		assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.after(2012, Month.JUNE, 16).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateAfterSameDateValues() {
-		assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.after(2012, Month.JUNE, 15));
+		assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.after(2012, Month.JUNE, 15).atZone(UTC));
 	}
 
 	@Test
 	public void isDateAfterEarlierDayMonthYear() {
-		assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.after(new DayMonthYear(14, Months.JUNE, 2012)));
+		assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.after(new DayMonthYear(14, Months.JUNE, 2012)).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateAfterLaterDayMonthYear() {
-		assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.after(new DayMonthYear(16, Months.JUNE, 2012)));
+		assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.after(new DayMonthYear(16, Months.JUNE, 2012)).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateAfterSameDayMonthYear() {
-		assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.after(new DayMonthYear(15, Months.JUNE, 2012)));
+		assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.after(new DayMonthYear(15, Months.JUNE, 2012)).atZone(UTC));
 	}
 
 	@Test
 	public void isDateAfterEarlierDateTime() {
-		assertThat(JUN_15_2012_11AM_AS_DATE, DateMatchers.after(2012, Months.JUNE, 15, 10, 59, 59));
+		assertThat(JUN_15_2012_11AM_UTC_AS_DATE, DateMatchers.after(2012, Months.JUNE, 15, 10, 59, 59).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateAfterLaterDateTime() {
-		assertThat(JUN_15_2012_11AM_AS_DATE, DateMatchers.after(2012, Months.JUNE, 15, 11, 00, 01));
+		assertThat(JUN_15_2012_11AM_UTC_AS_DATE, DateMatchers.after(2012, Months.JUNE, 15, 11, 0, 1).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateAfterSameDateTime() {
-		assertThat(JUN_15_2012_11AM_AS_DATE, DateMatchers.after(2012, Months.JUNE, 15, 11, 00, 00));
+		assertThat(JUN_15_2012_11AM_UTC_AS_DATE, DateMatchers.after(2012, Months.JUNE, 15, 11, 0, 0).atZone(UTC));
 	}
 
 	// LocalDate Matchers
@@ -197,52 +198,52 @@ public class IsAfterTest {
 
 	@Test
 	public void isZonedDateTimeAfterEarlierZonedDateTime() {
-		assertThat(AUG_04_2015_NOON_UTC, ZonedDateTimeMatchers.after(AUG_04_2015_11AM_UTC));
+		assertThat(AUG_04_2015_NOON_UTC, ZonedDateTimeMatchers.after(AUG_04_2015_11AM_UTC).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isZonedDateTimeAfterLaterZonedDateTime() {
-		assertThat(AUG_04_2015_NOON_UTC, ZonedDateTimeMatchers.after(AUG_04_2015_01PM_UTC));
+		assertThat(AUG_04_2015_NOON_UTC, ZonedDateTimeMatchers.after(AUG_04_2015_01PM_UTC).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isZonedDateTimeAfterSameZonedDateTime() {
-		assertThat(AUG_04_2015_NOON_UTC, ZonedDateTimeMatchers.after(AUG_04_2015_NOON_UTC));
+		assertThat(AUG_04_2015_NOON_UTC, ZonedDateTimeMatchers.after(AUG_04_2015_NOON_UTC).atZone(UTC));
 	}
 
 	@Test
 	public void isZonedDateTimeAfterZonedDateTimeEarlierZone() {
-		assertThat(AUG_04_2015_NOON_UTC, ZonedDateTimeMatchers.after(AUG_04_2015_NOON_CET));
+		assertThat(AUG_04_2015_NOON_UTC, ZonedDateTimeMatchers.after(AUG_04_2015_NOON_CET).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isZonedDateTimeAfterZonedDateTimeLaterZone() {
-		assertThat(AUG_04_2015_NOON_UTC, ZonedDateTimeMatchers.after(AUG_04_2015_NOON_EST));
+		assertThat(AUG_04_2015_NOON_UTC, ZonedDateTimeMatchers.after(AUG_04_2015_NOON_EST).atZone(UTC));
 	}
 
 	@Test
 	public void isZonedDateTimeAfterEarlierDateTime() {
-		assertThat(AUG_04_2015_NOON_UTC, ZonedDateTimeMatchers.after(2015, AUGUST, 4, 11, 59, 0, 0, ZoneIds.UTC));
+		assertThat(AUG_04_2015_NOON_UTC, ZonedDateTimeMatchers.after(2015, AUGUST, 4, 11, 59, 0, 0, UTC).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isZonedDateTimeAfterLaterDateTime() {
-		assertThat(AUG_04_2015_NOON_UTC, ZonedDateTimeMatchers.after(2015, AUGUST, 4, 12, 0, 1, 0, ZoneIds.UTC));
+		assertThat(AUG_04_2015_NOON_UTC, ZonedDateTimeMatchers.after(2015, AUGUST, 4, 12, 0, 1, 0, UTC).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isZonedDateTimeAfterLaterSameDateTime() {
-		assertThat(AUG_04_2015_NOON_UTC, ZonedDateTimeMatchers.after(2015, AUGUST, 4, 12, 0, 0, 0, ZoneIds.UTC));
+		assertThat(AUG_04_2015_NOON_UTC, ZonedDateTimeMatchers.after(2015, AUGUST, 4, 12, 0, 0, 0, UTC).atZone(UTC));
 	}
 
 	@Test
 	public void isZonedDateTimeAfterDateTimeEarlierZone() {
-		assertThat(AUG_04_2015_NOON_UTC, ZonedDateTimeMatchers.after(2015, AUGUST, 4, 12, 0, 0, 0, ZoneIds.CET));
+		assertThat(AUG_04_2015_NOON_UTC, ZonedDateTimeMatchers.after(2015, AUGUST, 4, 12, 0, 0, 0, ZoneIds.CET).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isZonedDateTimeAfterDateTimeLaterZone() {
-		assertThat(AUG_04_2015_NOON_UTC, ZonedDateTimeMatchers.after(2015, AUGUST, 4, 12, 0, 0, 0, ZoneIds.EST));
+		assertThat(AUG_04_2015_NOON_UTC, ZonedDateTimeMatchers.after(2015, AUGUST, 4, 12, 0, 0, 0, ZoneIds.EST).atZone(UTC));
 	}
 
 	// LocalTime Matchers

--- a/src/test/java/org/exparity/hamcrest/date/core/IsBeforeTest.java
+++ b/src/test/java/org/exparity/hamcrest/date/core/IsBeforeTest.java
@@ -3,6 +3,7 @@ package org.exparity.hamcrest.date.core;
 import static java.time.Month.AUGUST;
 import static org.exparity.hamcrest.date.ZonedDateTimeMatchers.before;
 import static org.exparity.hamcrest.date.testutils.Dates.*;
+import static org.exparity.hamcrest.date.testutils.ZoneIds.UTC;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.time.LocalTime;
@@ -26,108 +27,108 @@ import org.testng.annotations.Test;
 @SuppressWarnings("deprecation")
 public class IsBeforeTest {
 
-    private static final String ASSERTION_PATTERN = "\\s*Expected: the date is before [A-Za-z0-9:,.+ ]*\\s*but: date is [A-Za-z0-9:,.+ ]*";
+    private static final String ASSERTION_PATTERN = "\\sExpected: the date is before (?s:.)+?\\s     but: date is (?s:.)+";
 
     // Date Matchers
 
     @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
     public void isDateBeforeLaterDate() {
-        assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.before(JUN_15_2012_11AM_AS_DATE));
+        assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.before(JUN_15_2012_11AM_UTC_AS_DATE).atZone(UTC));
     }
 
     @Test
     public void isDateBeforeEarlierDate() {
-        assertThat(JUN_15_2012_11AM_AS_DATE, DateMatchers.before(JUN_15_2012_11PM_AS_DATE));
+        assertThat(JUN_15_2012_11AM_UTC_AS_DATE, DateMatchers.before(JUN_15_2012_11PM_UTC_AS_DATE).atZone(UTC));
     }
 
     @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
     public void isDateBeforeLaterSameDate() {
-        assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.before(JUN_15_2012_11PM_AS_DATE));
+        assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.before(JUN_15_2012_11PM_UTC_AS_DATE).atZone(UTC));
     }
 
     @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
     public void isDateBeforeLaterSameDateDifferentTimeZone() {
-        assertThat(JAN_01_2012_11AM_PST_AS_DATE, DateMatchers.before(JAN_01_2012_11AM_GMT_AS_DATE));
+        assertThat(JAN_01_2012_11AM_PST_AS_DATE, DateMatchers.before(JAN_01_2012_11AM_GMT_AS_DATE).atZone(UTC));
     }
 
     @Test
     public void isDateBeforeSameDateDifferentTimeZone() {
-        assertThat(JAN_01_2012_11AM_GMT_AS_DATE, DateMatchers.before(JAN_01_2012_11AM_PST_AS_DATE));
+        assertThat(JAN_01_2012_11AM_GMT_AS_DATE, DateMatchers.before(JAN_01_2012_11AM_PST_AS_DATE).atZone(UTC));
     }
 
     @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
     public void isDateBeforeLaterLocalDate() {
-        assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.before(JUN_14_2012));
+        assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.before(JUN_14_2012).atZone(UTC));
     }
 
     @Test
     public void isDateBeforeEarlierLocalDate() {
-        assertThat(JUN_15_2012_11AM_AS_DATE, DateMatchers.before(JUN_16_2012));
+        assertThat(JUN_15_2012_11AM_UTC_AS_DATE, DateMatchers.before(JUN_16_2012).atZone(UTC));
     }
 
     @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
     public void isDateBeforeLaterSameLocalDate() {
-        assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.before(JUN_15_2012));
+        assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.before(JUN_15_2012).atZone(UTC));
     }
 
     @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
     public void isDateBeforeLaterDeprecatedDateValues() {
-        assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.before(2012, Months.JUNE, 14));
+        assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.before(2012, Months.JUNE, 14).atZone(UTC));
     }
 
     @Test
     public void isDateBeforeEarlierDeprecatedDateValues() {
-        assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.before(2012, Months.JUNE, 16));
+        assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.before(2012, Months.JUNE, 16).atZone(UTC));
     }
 
     @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
     public void isDateBeforeLaterSameDeprecatedDateValues() {
-        assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.before(2012, Months.JUNE, 15));
+        assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.before(2012, Months.JUNE, 15).atZone(UTC));
     }
 
     @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
     public void isDateBeforeLaterDateValues() {
-        assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.before(2012, Month.JUNE, 14));
+        assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.before(2012, Month.JUNE, 14).atZone(UTC));
     }
 
     @Test
     public void isDateBeforeEarlierDateValues() {
-        assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.before(2012, Month.JUNE, 16));
+        assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.before(2012, Month.JUNE, 16).atZone(UTC));
     }
 
     @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
     public void isDateBeforeLaterSameDateValues() {
-        assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.before(2012, Month.JUNE, 15));
+        assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.before(2012, Month.JUNE, 15).atZone(UTC));
     }
 
     @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
     public void isDateBeforeLaterDayMonthYear() {
-        assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.before(new DayMonthYear(14, Months.JUNE, 2012)));
+        assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.before(new DayMonthYear(14, Months.JUNE, 2012)).atZone(UTC));
     }
 
     @Test
     public void isDateBeforeEarlierDayMonthYear() {
-        assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.before(new DayMonthYear(16, Months.JUNE, 2012)));
+        assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.before(new DayMonthYear(16, Months.JUNE, 2012)).atZone(UTC));
     }
 
     @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
     public void isDateBeforeLaterSameDayMonthYear() {
-        assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.before(new DayMonthYear(15, Months.JUNE, 2012)));
+        assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.before(new DayMonthYear(15, Months.JUNE, 2012)).atZone(UTC));
     }
 
     @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
     public void isDateBeforeLaterDateTime() {
-        assertThat(JUN_15_2012_11AM_AS_DATE, DateMatchers.before(2012, Months.JUNE, 15, 10, 59, 59));
+        assertThat(JUN_15_2012_11AM_UTC_AS_DATE, DateMatchers.before(2012, Months.JUNE, 15, 10, 59, 59).atZone(UTC));
     }
 
     @Test
     public void isDateBeforeEarlierDateTime() {
-        assertThat(JUN_15_2012_11AM_AS_DATE, DateMatchers.before(2012, Months.JUNE, 15, 11, 00, 01));
+        assertThat(JUN_15_2012_11AM_UTC_AS_DATE, DateMatchers.before(2012, Months.JUNE, 15, 11, 0, 1).atZone(UTC));
     }
 
     @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
     public void isDateBeforeLaterSameDateTime() {
-        assertThat(JUN_15_2012_11AM_AS_DATE, DateMatchers.before(2012, Months.JUNE, 15, 11, 00, 00));
+        assertThat(JUN_15_2012_11AM_UTC_AS_DATE, DateMatchers.before(2012, Months.JUNE, 15, 11, 0, 0).atZone(UTC));
     }
 
     // LocalDate Matchers

--- a/src/test/java/org/exparity/hamcrest/date/core/IsDayOfMonthTest.java
+++ b/src/test/java/org/exparity/hamcrest/date/core/IsDayOfMonthTest.java
@@ -13,7 +13,7 @@ import org.testng.annotations.Test;
  */
 public class IsDayOfMonthTest {
 
-    private static final String ASSERTION_PATTERN = "\\s*Expected: the date is on the [0-9]* day of the month\\s*but: the date is on the [0-9]* day of the month";
+    private static final String ASSERTION_PATTERN = "\\sExpected: the date has the day of month [0-9]+?\\s     but: the date has the day of month [0-9]+?";
 
 	// LocalDate Matchers
 	@Test

--- a/src/test/java/org/exparity/hamcrest/date/core/IsDayOfWeekTest.java
+++ b/src/test/java/org/exparity/hamcrest/date/core/IsDayOfWeekTest.java
@@ -1,6 +1,3 @@
-/**
- *
- */
 package org.exparity.hamcrest.date.core;
 
 import static java.time.DayOfWeek.MONDAY;
@@ -22,147 +19,149 @@ import org.testng.annotations.Test;
 @SuppressWarnings("deprecation")
 public class IsDayOfWeekTest {
 
-    private static final String ASSERTION_PATTERN = "\\s*Expected: the date is on a [A-Za-z ,]*\\s*but: the date is on a [A-Za-z]*";
+    private static final String ASSERTION_PATTERN = "\\sExpected: the date is on a \\p{IsAlphabetic}+?\\s     but: the date is on a \\p{IsAlphabetic}+";
+
+    private static final String ASSERTION_PATTERN_ANYOF = "\\sExpected: \\(the date is on a \\p{IsAlphabetic}+?( or the date is on a \\p{IsAlphabetic}+?)+?\\)\\s     but: the date is on a \\p{IsAlphabetic}+";
 
     // Date Matchers
     @Test
     public void isDateWeekdays() {
-        assertThat(JAN_01_2012_11AM_AS_DATE, DateMatchers.isDayOfWeek(Weekdays.SUNDAY));
+        assertThat(JAN_01_2012_11AM_UTC_AS_DATE, DateMatchers.isDayOfWeek(Weekdays.SUNDAY));
     }
 
     @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
     public void isDateNotWeekdays() {
-        assertThat(JAN_01_2012_11AM_AS_DATE, DateMatchers.isDayOfWeek(Weekdays.SATURDAY));
+        assertThat(JAN_01_2012_11AM_UTC_AS_DATE, DateMatchers.isDayOfWeek(Weekdays.SATURDAY));
     }
 
     @Test
     public void isDateDayOfWeek() {
-        assertThat(JAN_01_2012_11AM_AS_DATE, DateMatchers.isDayOfWeek(SUNDAY));
+        assertThat(JAN_01_2012_11AM_UTC_AS_DATE, DateMatchers.isDayOfWeek(SUNDAY));
     }
 
     @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
     public void isDateNotDayOfWeek() {
-        assertThat(JAN_01_2012_11AM_AS_DATE, DateMatchers.isDayOfWeek(SATURDAY));
+        assertThat(JAN_01_2012_11AM_UTC_AS_DATE, DateMatchers.isDayOfWeek(SATURDAY));
     }
 
     @Test
     public void isDateSaturday() {
-        assertThat(JAN_07_2012_11AM_AS_DATE, DateMatchers.isSaturday());
+        assertThat(JAN_07_2012_11AM_UTC_AS_DATE, DateMatchers.isSaturday());
     }
 
     @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
     public void isDateNotSaturday() {
-        assertThat(JAN_01_2012_11AM_AS_DATE, DateMatchers.isSaturday());
+        assertThat(JAN_01_2012_11AM_UTC_AS_DATE, DateMatchers.isSaturday());
     }
 
     @Test
     public void isDateSunday() {
-        assertThat(JAN_01_2012_11AM_AS_DATE, DateMatchers.isSunday());
+        assertThat(JAN_01_2012_11AM_UTC_AS_DATE, DateMatchers.isSunday());
     }
 
     @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
     public void isDateNotSunday() {
-        assertThat(JAN_02_2012_11AM_AS_DATE, DateMatchers.isSunday());
+        assertThat(JAN_02_2012_11AM_UTC_AS_DATE, DateMatchers.isSunday());
     }
 
     @Test
     public void isDateWeekend() {
-        assertThat(JAN_01_2012_11AM_AS_DATE, DateMatchers.isWeekend());
-        assertThat(JAN_07_2012_11AM_AS_DATE, DateMatchers.isWeekend());
+        assertThat(JAN_01_2012_11AM_UTC_AS_DATE, DateMatchers.isWeekend());
+        assertThat(JAN_07_2012_11AM_UTC_AS_DATE, DateMatchers.isWeekend());
     }
 
-    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
+    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN_ANYOF)
     public void isDateMondayIsNotWeekend() {
-        assertThat(JAN_02_2012_11AM_AS_DATE, DateMatchers.isWeekend());
+        assertThat(JAN_02_2012_11AM_UTC_AS_DATE, DateMatchers.isWeekend());
     }
 
-    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
+    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN_ANYOF)
     public void isDateTuesdayIsNotWeekend() {
-        assertThat(JAN_03_2012_11AM_AS_DATE, DateMatchers.isWeekend());
+        assertThat(JAN_03_2012_11AM_UTC_AS_DATE, DateMatchers.isWeekend());
     }
 
-    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
+    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN_ANYOF)
     public void isDateWednesdayIsNotWeekend() {
-        assertThat(JAN_04_2012_11AM_AS_DATE, DateMatchers.isWeekend());
+        assertThat(JAN_04_2012_11AM_UTC_AS_DATE, DateMatchers.isWeekend());
     }
 
-    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
+    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN_ANYOF)
     public void isDateThursdayIsNotWeekend() {
-        assertThat(JAN_05_2012_11AM_AS_DATE, DateMatchers.isWeekend());
+        assertThat(JAN_05_2012_11AM_UTC_AS_DATE, DateMatchers.isWeekend());
     }
 
-    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
+    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN_ANYOF)
     public void isDateFridayIsNotWeekend() {
-        assertThat(JAN_06_2012_11AM_AS_DATE, DateMatchers.isWeekend());
+        assertThat(JAN_06_2012_11AM_UTC_AS_DATE, DateMatchers.isWeekend());
     }
 
     @Test
     public void isDateWeekday() {
-        assertThat(JAN_02_2012_11AM_AS_DATE, DateMatchers.isWeekday());
-        assertThat(JAN_03_2012_11AM_AS_DATE, DateMatchers.isWeekday());
-        assertThat(JAN_04_2012_11AM_AS_DATE, DateMatchers.isWeekday());
-        assertThat(JAN_05_2012_11AM_AS_DATE, DateMatchers.isWeekday());
-        assertThat(JAN_06_2012_11AM_AS_DATE, DateMatchers.isWeekday());
+        assertThat(JAN_02_2012_11AM_UTC_AS_DATE, DateMatchers.isWeekday());
+        assertThat(JAN_03_2012_11AM_UTC_AS_DATE, DateMatchers.isWeekday());
+        assertThat(JAN_04_2012_11AM_UTC_AS_DATE, DateMatchers.isWeekday());
+        assertThat(JAN_05_2012_11AM_UTC_AS_DATE, DateMatchers.isWeekday());
+        assertThat(JAN_06_2012_11AM_UTC_AS_DATE, DateMatchers.isWeekday());
     }
 
-    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
+    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN_ANYOF)
     public void isDateSaturdayIsNotWeekday() {
-        assertThat(JAN_07_2012_11AM_AS_DATE, DateMatchers.isWeekday());
+        assertThat(JAN_07_2012_11AM_UTC_AS_DATE, DateMatchers.isWeekday());
     }
 
-    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
+    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN_ANYOF)
     public void isDateSundayIsNotWeekday() {
-        assertThat(JAN_01_2012_11AM_AS_DATE, DateMatchers.isWeekday());
+        assertThat(JAN_01_2012_11AM_UTC_AS_DATE, DateMatchers.isWeekday());
     }
 
     @Test
     public void isDateMonday() {
-        assertThat(JAN_02_2012_11AM_AS_DATE, DateMatchers.isMonday());
+        assertThat(JAN_02_2012_11AM_UTC_AS_DATE, DateMatchers.isMonday());
     }
 
     @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
     public void isDateNotMonday() {
-        assertThat(JAN_03_2012_11AM_AS_DATE, DateMatchers.isMonday());
+        assertThat(JAN_03_2012_11AM_UTC_AS_DATE, DateMatchers.isMonday());
     }
 
     @Test
     public void isDateTuesday() {
-        assertThat(JAN_03_2012_11AM_AS_DATE, DateMatchers.isTuesday());
+        assertThat(JAN_03_2012_11AM_UTC_AS_DATE, DateMatchers.isTuesday());
     }
 
     @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
     public void isDateNotTuesday() {
-        assertThat(JAN_04_2012_11AM_AS_DATE, DateMatchers.isTuesday());
+        assertThat(JAN_04_2012_11AM_UTC_AS_DATE, DateMatchers.isTuesday());
     }
 
     @Test
     public void isDateWednesday() {
-        assertThat(JAN_04_2012_11AM_AS_DATE, DateMatchers.isWednesday());
+        assertThat(JAN_04_2012_11AM_UTC_AS_DATE, DateMatchers.isWednesday());
     }
 
     @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
     public void isDateNotWednesday() {
-        assertThat(JAN_05_2012_11AM_AS_DATE, DateMatchers.isWednesday());
+        assertThat(JAN_05_2012_11AM_UTC_AS_DATE, DateMatchers.isWednesday());
     }
 
     @Test
     public void isDateThursday() {
-        assertThat(JAN_05_2012_11AM_AS_DATE, DateMatchers.isThursday());
+        assertThat(JAN_05_2012_11AM_UTC_AS_DATE, DateMatchers.isThursday());
     }
 
     @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
     public void isDateNotThursday() {
-        assertThat(JAN_06_2012_11AM_AS_DATE, DateMatchers.isThursday());
+        assertThat(JAN_06_2012_11AM_UTC_AS_DATE, DateMatchers.isThursday());
     }
 
     @Test
     public void isDateFriday() {
-        assertThat(JAN_06_2012_11AM_AS_DATE, DateMatchers.isFriday());
+        assertThat(JAN_06_2012_11AM_UTC_AS_DATE, DateMatchers.isFriday());
     }
 
     @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
     public void isDateNotFriday() {
-        assertThat(JAN_07_2012_11AM_AS_DATE, DateMatchers.isFriday());
+        assertThat(JAN_07_2012_11AM_UTC_AS_DATE, DateMatchers.isFriday());
     }
 
     // Local Date Matchers
@@ -255,12 +254,12 @@ public class IsDayOfWeekTest {
         assertThat(AUG_07_2015, LocalDateMatchers.isWeekday());
     }
 
-    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
+    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN_ANYOF)
     public void isLocalDateNotWeekdayOnSaturday() {
         assertThat(AUG_08_2015, LocalDateMatchers.isWeekday());
     }
 
-    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
+    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN_ANYOF)
     public void isLocalDateNotWeekdayOnSunday() {
         assertThat(AUG_09_2015, LocalDateMatchers.isWeekday());
     }
@@ -271,27 +270,27 @@ public class IsDayOfWeekTest {
         assertThat(AUG_09_2015, LocalDateMatchers.isWeekend());
     }
 
-    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
+    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN_ANYOF)
     public void isLocalDateNotWeekendOnMonday() {
         assertThat(AUG_03_2015, LocalDateMatchers.isWeekend());
     }
 
-    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
+    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN_ANYOF)
     public void isLocalDateNotWeekendOnTuesday() {
         assertThat(AUG_04_2015, LocalDateMatchers.isWeekend());
     }
 
-    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
+    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN_ANYOF)
     public void isLocalDateNotWeekendOnWednesday() {
         assertThat(AUG_05_2015, LocalDateMatchers.isWeekend());
     }
 
-    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
+    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN_ANYOF)
     public void isLocalDateNotWeekendOnThursday() {
         assertThat(AUG_06_2015, LocalDateMatchers.isWeekend());
     }
 
-    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
+    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN_ANYOF)
     public void isLocalDateNotWeekendOnFriday() {
         assertThat(AUG_07_2015, LocalDateMatchers.isWeekend());
     }
@@ -386,12 +385,12 @@ public class IsDayOfWeekTest {
         assertThat(AUG_07_2015_NOON, LocalDateTimeMatchers.isWeekday());
     }
 
-    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
+    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN_ANYOF)
     public void isLocalDateTimeNotWeekdayOnSaturday() {
         assertThat(AUG_08_2015_NOON, LocalDateTimeMatchers.isWeekday());
     }
 
-    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
+    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN_ANYOF)
     public void isLocalDateTimeNotWeekdayOnSunday() {
         assertThat(AUG_09_2015_NOON, LocalDateTimeMatchers.isWeekday());
     }
@@ -402,27 +401,27 @@ public class IsDayOfWeekTest {
         assertThat(AUG_09_2015_NOON, LocalDateTimeMatchers.isWeekend());
     }
 
-    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
+    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN_ANYOF)
     public void isLocalDateTimeNotWeekendOnMonday() {
         assertThat(AUG_03_2015_NOON, LocalDateTimeMatchers.isWeekend());
     }
 
-    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
+    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN_ANYOF)
     public void isLocalDateTimeNotWeekendOnTuesday() {
         assertThat(AUG_04_2015_NOON, LocalDateTimeMatchers.isWeekend());
     }
 
-    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
+    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN_ANYOF)
     public void isLocalDateTimeNotWeekendOnWednesday() {
         assertThat(AUG_05_2015_NOON, LocalDateTimeMatchers.isWeekend());
     }
 
-    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
+    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN_ANYOF)
     public void isLocalDateTimeNotWeekendOnThursday() {
         assertThat(AUG_06_2015_NOON, LocalDateTimeMatchers.isWeekend());
     }
 
-    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
+    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN_ANYOF)
     public void isLocalDateTimeNotWeekendOnFriday() {
         assertThat(AUG_07_2015_NOON, LocalDateTimeMatchers.isWeekend());
     }
@@ -517,12 +516,12 @@ public class IsDayOfWeekTest {
         assertThat(AUG_07_2015_NOON_UTC, ZonedDateTimeMatchers.isWeekday());
     }
 
-    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
+    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN_ANYOF)
     public void isZonedDateTimeNotWeekdayOnSaturday() {
         assertThat(AUG_08_2015_NOON_UTC, ZonedDateTimeMatchers.isWeekday());
     }
 
-    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
+    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN_ANYOF)
     public void isZonedDateTimeNotWeekdayOnSunday() {
         assertThat(AUG_09_2015_NOON_UTC, ZonedDateTimeMatchers.isWeekday());
     }
@@ -533,27 +532,27 @@ public class IsDayOfWeekTest {
         assertThat(AUG_09_2015_NOON_UTC, ZonedDateTimeMatchers.isWeekend());
     }
 
-    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
+    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN_ANYOF)
     public void isZonedDateTimeNotWeekendOnMonday() {
         assertThat(AUG_03_2015_NOON_UTC, ZonedDateTimeMatchers.isWeekend());
     }
 
-    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
+    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN_ANYOF)
     public void isZonedDateTimeNotWeekendOnTuesday() {
         assertThat(AUG_04_2015_NOON_UTC, ZonedDateTimeMatchers.isWeekend());
     }
 
-    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
+    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN_ANYOF)
     public void isZonedDateTimeNotWeekendOnWednesday() {
         assertThat(AUG_05_2015_NOON_UTC, ZonedDateTimeMatchers.isWeekend());
     }
 
-    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
+    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN_ANYOF)
     public void isZonedDateTimeNotWeekendOnThursday() {
         assertThat(AUG_06_2015_NOON_UTC, ZonedDateTimeMatchers.isWeekend());
     }
 
-    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
+    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN_ANYOF)
     public void isZonedDateTimeNotWeekendOnFriday() {
         assertThat(AUG_07_2015_NOON_UTC, ZonedDateTimeMatchers.isWeekend());
     }

--- a/src/test/java/org/exparity/hamcrest/date/core/IsDayTest.java
+++ b/src/test/java/org/exparity/hamcrest/date/core/IsDayTest.java
@@ -21,7 +21,7 @@ import org.testng.annotations.Test;
  */
 public class IsDayTest {
 
-    private static final String ASSERTION_PATTERN = "\\s*Expected: the same day as [A-Za-z0-9:,.+ ]*\\s*but: the day is [A-Za-z0-9:,.+ ]*";
+    private static final String ASSERTION_PATTERN = "\\sExpected: the same day as (?s:.)+?\\s     but: the day is (?s:.)+";
 
 	// Date Matchers
 	@Test

--- a/src/test/java/org/exparity/hamcrest/date/core/IsFirstDayOfMonthTest.java
+++ b/src/test/java/org/exparity/hamcrest/date/core/IsFirstDayOfMonthTest.java
@@ -14,17 +14,17 @@ import org.testng.annotations.Test;
  */
 public class IsFirstDayOfMonthTest {
 
-    private static final String ASSERTION_PATTERN = "\\s*Expected: the date is the first day of the month\\s*but: date is the [0-9]* [A-Za-z ]* instead of [0-9]* [A-Za-z ]*";
+    private static final String ASSERTION_PATTERN = "\\sExpected: the date is the first day of the month\\s     but: date is the [0-9]+? day of month instead of [0-9]+? day of month";
 
 	// Date Matchers
 	@Test
 	public void isDateFirstDayOfMonth() {
-		assertThat(AUG_01_2015_NOON_AS_DATE, DateMatchers.isFirstDayOfMonth());
+		assertThat(AUG_01_2015_NOON_UTC_AS_DATE, DateMatchers.isFirstDayOfMonth());
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateNotFirstDayOfMonth() {
-		assertThat(AUG_31_2015_NOON_AS_DATE, DateMatchers.isFirstDayOfMonth());
+		assertThat(AUG_31_2015_NOON_UTC_AS_DATE, DateMatchers.isFirstDayOfMonth());
 	}
 
 	// LocalDate Matchers

--- a/src/test/java/org/exparity/hamcrest/date/core/IsHourTest.java
+++ b/src/test/java/org/exparity/hamcrest/date/core/IsHourTest.java
@@ -1,47 +1,50 @@
 package org.exparity.hamcrest.date.core;
 
 import static org.exparity.hamcrest.date.testutils.Dates.AUG_04_2015_NOON;
-import static org.exparity.hamcrest.date.testutils.Dates.AUG_04_2015_NOON_AS_DATE;
+import static org.exparity.hamcrest.date.testutils.Dates.AUG_04_2015_NOON_UTC_AS_DATE;
 import static org.exparity.hamcrest.date.testutils.Dates.AUG_04_2015_NOON_UTC;
+import static org.exparity.hamcrest.date.testutils.ZoneIds.UTC;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.time.LocalTime;
+import java.time.ZoneId;
 
 import org.exparity.hamcrest.date.DateMatchers;
 import org.exparity.hamcrest.date.LocalDateTimeMatchers;
 import org.exparity.hamcrest.date.LocalTimeMatchers;
 import org.exparity.hamcrest.date.ZonedDateTimeMatchers;
+import org.exparity.hamcrest.date.testutils.ZoneIds;
 import org.testng.annotations.Test;
 
 /**
- * Unit Tests for the {@link IsSameHourOfDay} class
+ * Unit Tests for the {@link IsHour} class
  *
  * @author Stewart Bissett
  */
 @SuppressWarnings("deprecation")
 public class IsHourTest {
 
-    private static final String ASSERTION_PATTERN = "\\s*Expected: the date has the hour [0-9]*\\s*but: the date has the hour [0-9]*";
+    private static final String ASSERTION_PATTERN = "\\sExpected: the date has the hour [0-9]+?\\s     but: the date has the hour [0-9]+";
 
 	// Date Matchers
 	@Test
 	public void isDateHour() {
-		assertThat(AUG_04_2015_NOON_AS_DATE, DateMatchers.isHour(12));
+		assertThat(AUG_04_2015_NOON_UTC_AS_DATE, DateMatchers.isHour(12).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateNotHour() {
-		assertThat(AUG_04_2015_NOON_AS_DATE, DateMatchers.isHour(11));
+		assertThat(AUG_04_2015_NOON_UTC_AS_DATE, DateMatchers.isHour(11).atZone(UTC));
 	}
 
-    @Test
+	@Test
 	public void isDateSameHour() {
-		assertThat(AUG_04_2015_NOON_AS_DATE, DateMatchers.sameHour(12));
+		assertThat(AUG_04_2015_NOON_UTC_AS_DATE, DateMatchers.sameHour(12).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateNotSameHour() {
-		assertThat(AUG_04_2015_NOON_AS_DATE, DateMatchers.sameHour(11));
+		assertThat(AUG_04_2015_NOON_UTC_AS_DATE, DateMatchers.sameHour(11).atZone(UTC));
 	}
 
 	// LocalDateTime Matchers
@@ -69,12 +72,22 @@ public class IsHourTest {
 	// ZonedDateTime Matchers
 	@Test
 	public void isZonedDateTimeHour() {
-		assertThat(AUG_04_2015_NOON_UTC, ZonedDateTimeMatchers.isHour(12));
+		assertThat(AUG_04_2015_NOON_UTC, ZonedDateTimeMatchers.isHour(12).atZone(ZoneIds.UTC));
+	}
+
+	@Test
+	public void isZonedDateTimeHourOtherZone() {
+		assertThat(AUG_04_2015_NOON_UTC, ZonedDateTimeMatchers.isHour(8).atZone(ZoneIds.EST));
+	}
+
+	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
+	public void isZonedDateTimeNotHourOtherZone() {
+		assertThat(AUG_04_2015_NOON_UTC, ZonedDateTimeMatchers.isHour(12).atZone(ZoneIds.CET));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isZonedDateTimeNotHour() {
-		assertThat(AUG_04_2015_NOON_UTC, ZonedDateTimeMatchers.isHour(11));
+		assertThat(AUG_04_2015_NOON_UTC, ZonedDateTimeMatchers.isHour(11).atZone(ZoneIds.UTC));
 	}
 
 }

--- a/src/test/java/org/exparity/hamcrest/date/core/IsLastDayOfMonthTest.java
+++ b/src/test/java/org/exparity/hamcrest/date/core/IsLastDayOfMonthTest.java
@@ -14,17 +14,17 @@ import org.testng.annotations.Test;
  */
 public class IsLastDayOfMonthTest {
 
-    private static final String ASSERTION_PATTERN = "\\s*Expected: the date is the last day of the month\\s*but: date is the [0-9]* [A-Za-z ]* instead of [0-9]* [A-Za-z ]*";
+    private static final String ASSERTION_PATTERN = "\\sExpected: the date is the last day of the month\\s     but: date is the [0-9]+? day of month instead of [0-9]+? day of month";
 
 	// Date Matchers
 	@Test
 	public void isDateLastDayOfMonth() {
-		assertThat(AUG_31_2015_NOON_AS_DATE, DateMatchers.isLastDayOfMonth());
+		assertThat(AUG_31_2015_NOON_UTC_AS_DATE, DateMatchers.isLastDayOfMonth());
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateNotLastDayOfMonth() {
-		assertThat(AUG_01_2015_NOON_AS_DATE, DateMatchers.isLastDayOfMonth());
+		assertThat(AUG_01_2015_NOON_UTC_AS_DATE, DateMatchers.isLastDayOfMonth());
 	}
 
 	// LocalDate Matchers

--- a/src/test/java/org/exparity/hamcrest/date/core/IsLeapYearTest.java
+++ b/src/test/java/org/exparity/hamcrest/date/core/IsLeapYearTest.java
@@ -8,6 +8,7 @@ import org.exparity.hamcrest.date.DateMatchers;
 import org.exparity.hamcrest.date.LocalDateMatchers;
 import org.exparity.hamcrest.date.LocalDateTimeMatchers;
 import org.exparity.hamcrest.date.ZonedDateTimeMatchers;
+import org.exparity.hamcrest.date.testutils.ZoneIds;
 import org.testng.annotations.Test;
 
 /**
@@ -17,17 +18,27 @@ import org.testng.annotations.Test;
  */
 public class IsLeapYearTest {
 
-    private static final String ASSERTION_PATTERN = "\\s*Expected: a leap year*\\s*but: the date [A-Za-z0-9:,.+ \\-]* is not a leap year";
+    private static final String ASSERTION_PATTERN = "\\sExpected: a leap year\\s     but: the date (?s:.)+? is not a leap year";
 
 	// Date Matchers
 	@Test
 	public void isDateLeapYear() {
-		assertThat(AUG_04_2016_AS_DATE, DateMatchers.isLeapYear());
+		assertThat(AUG_04_2016_MIDNIGHT_UTC_AS_DATE, DateMatchers.isLeapYear());
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateNotLeapYear() {
-		assertThat(AUG_04_2015_NOON_AS_DATE, DateMatchers.isLeapYear());
+		assertThat(AUG_04_2015_NOON_UTC_AS_DATE, DateMatchers.isLeapYear());
+	}
+
+	@Test
+	public void isDateLeapYearStartOfYearSameZone() {
+		assertThat(JAN_01_2012_MIDNIGHT_CET_AS_DATE, DateMatchers.isLeapYear().atZone(ZoneIds.CET));
+	}
+
+	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
+	public void isDateNotLeapYearStartOfYearLaterZone() {
+		assertThat(JAN_01_2012_MIDNIGHT_CET_AS_DATE, DateMatchers.isLeapYear().atZone(ZoneIds.UTC));
 	}
 
 	// LocalDate Matchers
@@ -61,6 +72,16 @@ public class IsLeapYearTest {
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isZonedDateTimeNotLeapYear() {
 		assertThat(AUG_04_2015_NOON_UTC, ZonedDateTimeMatchers.isLeapYear());
+	}
+
+	@Test
+	public void isZonedDateLeapYearStartOfYearSameZone() {
+		assertThat(JAN_01_2012_MIDNIGHT_CET, ZonedDateTimeMatchers.isLeapYear().atZone(ZoneIds.CET));
+	}
+
+	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
+	public void isZonedDateNotLeapYearStartOfYearLaterZone() {
+		assertThat(JAN_01_2012_MIDNIGHT_CET, ZonedDateTimeMatchers.isLeapYear().atZone(ZoneIds.UTC));
 	}
 
 }

--- a/src/test/java/org/exparity/hamcrest/date/core/IsMaximumTest.java
+++ b/src/test/java/org/exparity/hamcrest/date/core/IsMaximumTest.java
@@ -18,17 +18,17 @@ import org.testng.annotations.Test;
  */
 public class IsMaximumTest {
 
-    private static final String ASSERTION_PATTERN = "\\s*Expected: the date is the maximum value for [A-Za-z ]*\\s*but: date is the [0-9]* [A-Za-z ]* instead of [0-9]* [A-Za-z ]*";
+    private static final String ASSERTION_PATTERN = "\\sExpected: the date is the maximum value for [\\w ]+?\\s     but: date is the [0-9]+? [\\w ]+? instead of [0-9]+? [\\w ]+";
 
     // Date Matchers
     @Test
     public void isDateLastDayOfMonth() {
-        assertThat(AUG_31_2015_NOON_AS_DATE, DateMatchers.isMaximum(ChronoField.DAY_OF_MONTH));
+        assertThat(AUG_31_2015_NOON_UTC_AS_DATE, DateMatchers.isMaximum(ChronoField.DAY_OF_MONTH));
     }
 
     @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
     public void isDateNotLastDayOfMonth() {
-        assertThat(AUG_01_2015_NOON_AS_DATE, DateMatchers.isMaximum(ChronoField.DAY_OF_MONTH));
+        assertThat(AUG_01_2015_NOON_UTC_AS_DATE, DateMatchers.isMaximum(ChronoField.DAY_OF_MONTH));
     }
 
     // LocalDate Matchers

--- a/src/test/java/org/exparity/hamcrest/date/core/IsMillisecondTest.java
+++ b/src/test/java/org/exparity/hamcrest/date/core/IsMillisecondTest.java
@@ -1,40 +1,40 @@
 package org.exparity.hamcrest.date.core;
 
-import static org.exparity.hamcrest.date.testutils.Dates.AUG_04_2015_NOON_AS_DATE;
+import static org.exparity.hamcrest.date.testutils.Dates.AUG_04_2015_NOON_UTC_AS_DATE;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.exparity.hamcrest.date.DateMatchers;
 import org.testng.annotations.Test;
 
 /**
- * Unit Tests for the {@link IsSameMillisecondOfDay} class
+ * Unit Tests for the {@link IsMillisecond} class
  *
  * @author Stewart Bissett
  */
 @SuppressWarnings("deprecation")
 public class IsMillisecondTest {
 
-    private static final String ASSERTION_PATTERN = "\\s*Expected: the date has the millisecond [0-9]*\\s*but: the date has the millisecond [A-Za-z0-9:,.+ ]*";
+    private static final String ASSERTION_PATTERN = "\\sExpected: the date has the millisecond [0-9]+?\\s     but: the date has the millisecond [0-9]+";
 
 	// Date Matchers
 	@Test
 	public void isDateMillisecond() {
-		assertThat(AUG_04_2015_NOON_AS_DATE, DateMatchers.isMillisecond(0));
+		assertThat(AUG_04_2015_NOON_UTC_AS_DATE, DateMatchers.isMillisecond(0));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateNotMillisecond() {
-		assertThat(AUG_04_2015_NOON_AS_DATE, DateMatchers.isMillisecond(1));
+		assertThat(AUG_04_2015_NOON_UTC_AS_DATE, DateMatchers.isMillisecond(1));
 	}
 
 	@Test
 	public void isDateSameMillisecond() {
-		assertThat(AUG_04_2015_NOON_AS_DATE, DateMatchers.sameMillisecond(0));
+		assertThat(AUG_04_2015_NOON_UTC_AS_DATE, DateMatchers.sameMillisecond(0));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateNotSameMillisecond() {
-		assertThat(AUG_04_2015_NOON_AS_DATE, DateMatchers.sameMillisecond(1));
+		assertThat(AUG_04_2015_NOON_UTC_AS_DATE, DateMatchers.sameMillisecond(1));
 	}
 
 }

--- a/src/test/java/org/exparity/hamcrest/date/core/IsMinimumTest.java
+++ b/src/test/java/org/exparity/hamcrest/date/core/IsMinimumTest.java
@@ -18,17 +18,17 @@ import org.testng.annotations.Test;
  */
 public class IsMinimumTest {
 
-    private static final String ASSERTION_PATTERN = "\\s*Expected: the date is the minimum value for [A-Za-z ]*\\s*but: date is the [0-9]* [A-Za-z ]* instead of [0-9]* [A-Za-z ]*";
+    private static final String ASSERTION_PATTERN = "\\sExpected: the date is the minimum value for [\\w ]+?\\s     but: date is the [0-9]+? [\\w ]+? instead of [0-9]+? [\\w ]+?";
 
     // Date Matchers
     @Test
     public void isDateFirstDayOfMonth() {
-        assertThat(AUG_01_2015_NOON_AS_DATE, DateMatchers.isMinimum(ChronoField.DAY_OF_MONTH));
+        assertThat(AUG_01_2015_NOON_UTC_AS_DATE, DateMatchers.isMinimum(ChronoField.DAY_OF_MONTH));
     }
 
     @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
     public void isDateNotFirstDayOfMonth() {
-        assertThat(AUG_31_2015_NOON_AS_DATE, DateMatchers.isMinimum(ChronoField.DAY_OF_MONTH));
+        assertThat(AUG_31_2015_NOON_UTC_AS_DATE, DateMatchers.isMinimum(ChronoField.DAY_OF_MONTH));
     }
 
     // LocalDate Matchers

--- a/src/test/java/org/exparity/hamcrest/date/core/IsMinuteTest.java
+++ b/src/test/java/org/exparity/hamcrest/date/core/IsMinuteTest.java
@@ -1,7 +1,7 @@
 package org.exparity.hamcrest.date.core;
 
 import static org.exparity.hamcrest.date.testutils.Dates.AUG_04_2015_NOON;
-import static org.exparity.hamcrest.date.testutils.Dates.AUG_04_2015_NOON_AS_DATE;
+import static org.exparity.hamcrest.date.testutils.Dates.AUG_04_2015_NOON_UTC_AS_DATE;
 import static org.exparity.hamcrest.date.testutils.Dates.AUG_04_2015_NOON_UTC;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -14,34 +14,34 @@ import org.exparity.hamcrest.date.ZonedDateTimeMatchers;
 import org.testng.annotations.Test;
 
 /**
- * Unit Tests for the {@link IsSameMinuteOfDay} class
+ * Unit Tests for the {@link IsMinute} class
  *
  * @author Stewart Bissett
  */
 @SuppressWarnings("deprecation")
 public class IsMinuteTest {
 
-    private static final String ASSERTION_PATTERN = "\\s*Expected: the date has the minute [0-9]*\\s*but: the date has the minute [0-9]*";
+    private static final String ASSERTION_PATTERN = "\\sExpected: the date has the minute [0-9]+?\\s     but: the date has the minute [0-9]+";
 
 	// Date Matchers
 	@Test
 	public void isDateMinute() {
-		assertThat(AUG_04_2015_NOON_AS_DATE, DateMatchers.isMinute(0));
+		assertThat(AUG_04_2015_NOON_UTC_AS_DATE, DateMatchers.isMinute(0));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateNotMinute() {
-		assertThat(AUG_04_2015_NOON_AS_DATE, DateMatchers.isMinute(1));
+		assertThat(AUG_04_2015_NOON_UTC_AS_DATE, DateMatchers.isMinute(1));
 	}
 
 	@Test
 	public void isDateSameMinute() {
-		assertThat(AUG_04_2015_NOON_AS_DATE, DateMatchers.sameMinute(0));
+		assertThat(AUG_04_2015_NOON_UTC_AS_DATE, DateMatchers.sameMinute(0));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateNotSameMinute() {
-		assertThat(AUG_04_2015_NOON_AS_DATE, DateMatchers.sameMinute(1));
+		assertThat(AUG_04_2015_NOON_UTC_AS_DATE, DateMatchers.sameMinute(1));
 	}
 
 	// LocalDateTime Matchers

--- a/src/test/java/org/exparity/hamcrest/date/core/IsMonthTest.java
+++ b/src/test/java/org/exparity/hamcrest/date/core/IsMonthTest.java
@@ -13,154 +13,154 @@ import org.exparity.hamcrest.date.ZonedDateTimeMatchers;
 import org.testng.annotations.Test;
 
 /**
- * Unit Tests for the {@link IsSameMonthOfYear} class
+ * Unit Tests for the {@link IsMonth} class
  *
  * @author Stewart Bissett
  */
 @SuppressWarnings("deprecation")
 public class IsMonthTest {
 
-    private static final String ASSERTION_PATTERN = "\\s*Expected: the date is in [A-Za-z]*\\s*but: the date is in [A-Za-z]*";
+    private static final String ASSERTION_PATTERN = "\\sExpected: the date has the month [0-9]+?\\s     but: the date has the month [0-9]+?";
 
 	// Date Matchers
 	@Test
 	public void isDateMonth() {
-		assertThat(JAN_01_2015_NOON_AS_DATE, DateMatchers.isMonth(Month.JANUARY));
+		assertThat(JAN_01_2015_NOON_UTC_AS_DATE, DateMatchers.isMonth(Month.JANUARY));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateNotMonth() {
-		assertThat(JAN_01_2015_NOON_AS_DATE, DateMatchers.isMonth(Month.FEBRUARY));
+		assertThat(JAN_01_2015_NOON_UTC_AS_DATE, DateMatchers.isMonth(Month.FEBRUARY));
 	}
 
 	@Test
 	public void isDateSameMonth() {
-		assertThat(JAN_01_2015_NOON_AS_DATE, DateMatchers.sameMonth(Months.JANUARY));
+		assertThat(JAN_01_2015_NOON_UTC_AS_DATE, DateMatchers.sameMonth(Months.JANUARY));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateNotSameMonth() {
-		assertThat(JAN_01_2015_NOON_AS_DATE, DateMatchers.sameMonth(Months.FEBRUARY));
+		assertThat(JAN_01_2015_NOON_UTC_AS_DATE, DateMatchers.sameMonth(Months.FEBRUARY));
 	}
 
 	@Test
 	public void isDateJanuary() {
-		assertThat(JAN_01_2015_NOON_AS_DATE, DateMatchers.isJanuary());
+		assertThat(JAN_01_2015_NOON_UTC_AS_DATE, DateMatchers.isJanuary());
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateNotJanuary() {
-		assertThat(AUG_04_2015_NOON_AS_DATE, DateMatchers.isJanuary());
+		assertThat(AUG_04_2015_NOON_UTC_AS_DATE, DateMatchers.isJanuary());
 	}
 
 	@Test
 	public void isDateFebruary() {
-		assertThat(FEB_01_2015_NOON_AS_DATE, DateMatchers.isFebruary());
+		assertThat(FEB_01_2015_NOON_UTC_AS_DATE, DateMatchers.isFebruary());
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateNotFebruary() {
-		assertThat(AUG_04_2015_NOON_AS_DATE, DateMatchers.isFebruary());
+		assertThat(AUG_04_2015_NOON_UTC_AS_DATE, DateMatchers.isFebruary());
 	}
 
 	@Test
 	public void isDateMarch() {
-		assertThat(MAR_01_2015_NOON_AS_DATE, DateMatchers.isMarch());
+		assertThat(MAR_01_2015_NOON_UTC_AS_DATE, DateMatchers.isMarch());
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateNotMarch() {
-		assertThat(AUG_04_2015_NOON_AS_DATE, DateMatchers.isMarch());
+		assertThat(AUG_04_2015_NOON_UTC_AS_DATE, DateMatchers.isMarch());
 	}
 
 	@Test
 	public void isDateApril() {
-		assertThat(APR_01_2015_NOON_AS_DATE, DateMatchers.isApril());
+		assertThat(APR_01_2015_NOON_UTC_AS_DATE, DateMatchers.isApril());
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateNotApril() {
-		assertThat(AUG_04_2015_NOON_AS_DATE, DateMatchers.isApril());
+		assertThat(AUG_04_2015_NOON_UTC_AS_DATE, DateMatchers.isApril());
 	}
 
 	@Test
 	public void isDateMay() {
-		assertThat(MAY_01_2015_NOON_AS_DATE, DateMatchers.isMay());
+		assertThat(MAY_01_2015_NOON_UTC_AS_DATE, DateMatchers.isMay());
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateNotMay() {
-		assertThat(AUG_04_2015_NOON_AS_DATE, DateMatchers.isMay());
+		assertThat(AUG_04_2015_NOON_UTC_AS_DATE, DateMatchers.isMay());
 	}
 
 	@Test
 	public void isDateJune() {
-		assertThat(JUN_01_2015_NOON_AS_DATE, DateMatchers.isJune());
+		assertThat(JUN_01_2015_NOON_UTC_AS_DATE, DateMatchers.isJune());
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateNotJune() {
-		assertThat(AUG_04_2015_NOON_AS_DATE, DateMatchers.isJune());
+		assertThat(AUG_04_2015_NOON_UTC_AS_DATE, DateMatchers.isJune());
 	}
 
 	@Test
 	public void isDateJuly() {
-		assertThat(JUL_01_2015_NOON_AS_DATE, DateMatchers.isJuly());
+		assertThat(JUL_01_2015_NOON_UTC_AS_DATE, DateMatchers.isJuly());
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateNotJuly() {
-		assertThat(AUG_04_2015_NOON_AS_DATE, DateMatchers.isJuly());
+		assertThat(AUG_04_2015_NOON_UTC_AS_DATE, DateMatchers.isJuly());
 	}
 
 	@Test
 	public void isDateAugust() {
-		assertThat(AUG_01_2015_NOON_AS_DATE, DateMatchers.isAugust());
+		assertThat(AUG_01_2015_NOON_UTC_AS_DATE, DateMatchers.isAugust());
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateNotAugust() {
-		assertThat(SEP_04_2015_AS_DATE, DateMatchers.isAugust());
+		assertThat(SEP_04_2015_MIDNIGHT_UTC_AS_DATE, DateMatchers.isAugust());
 	}
 
 	@Test
 	public void isDateSeptember() {
-		assertThat(SEP_04_2015_AS_DATE, DateMatchers.isSeptember());
+		assertThat(SEP_04_2015_MIDNIGHT_UTC_AS_DATE, DateMatchers.isSeptember());
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateNotSeptember() {
-		assertThat(AUG_04_2015_NOON_AS_DATE, DateMatchers.isSeptember());
+		assertThat(AUG_04_2015_NOON_UTC_AS_DATE, DateMatchers.isSeptember());
 	}
 
 	@Test
 	public void isDateOctober() {
-		assertThat(OCT_01_2015_NOON_AS_DATE, DateMatchers.isOctober());
+		assertThat(OCT_01_2015_NOON_UTC_AS_DATE, DateMatchers.isOctober());
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateNotOctober() {
-		assertThat(AUG_04_2015_NOON_AS_DATE, DateMatchers.isOctober());
+		assertThat(AUG_04_2015_NOON_UTC_AS_DATE, DateMatchers.isOctober());
 	}
 
 	@Test
 	public void isDateNovember() {
-		assertThat(NOV_01_2015_NOON_AS_DATE, DateMatchers.isNovember());
+		assertThat(NOV_01_2015_NOON_UTC_AS_DATE, DateMatchers.isNovember());
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateNotNovember() {
-		assertThat(AUG_04_2015_NOON_AS_DATE, DateMatchers.isNovember());
+		assertThat(AUG_04_2015_NOON_UTC_AS_DATE, DateMatchers.isNovember());
 	}
 
 	@Test
 	public void isDateDecember() {
-		assertThat(DEC_01_2015_NOON_AS_DATE, DateMatchers.isDecember());
+		assertThat(DEC_01_2015_NOON_UTC_AS_DATE, DateMatchers.isDecember());
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateNotDecember() {
-		assertThat(AUG_04_2015_NOON_AS_DATE, DateMatchers.isDecember());
+		assertThat(AUG_04_2015_NOON_UTC_AS_DATE, DateMatchers.isDecember());
 	}
 
 	// LocalDate Matchers

--- a/src/test/java/org/exparity/hamcrest/date/core/IsSameDayOfMonthTest.java
+++ b/src/test/java/org/exparity/hamcrest/date/core/IsSameDayOfMonthTest.java
@@ -14,22 +14,22 @@ import org.testng.annotations.Test;
  */
 public class IsSameDayOfMonthTest {
 
-    private static final String ASSERTION_PATTERN = "\\s*Expected: the date is on the [0-9]* day of the month\\s*but: the date is on the [0-9]* day of the month";
+    private static final String ASSERTION_PATTERN = "\\sExpected: the date has the day of month [0-9]+?\\s     but: the date has the day of month [0-9]+?";
 
 	// Date Matchers
 	@Test
 	public void isDateSameDayOfMonth() {
-		assertThat(AUG_04_2015_NOON_AS_DATE, DateMatchers.sameDayOfMonth(AUG_04_2015_NOON_AS_DATE));
+		assertThat(AUG_04_2015_NOON_UTC_AS_DATE, DateMatchers.sameDayOfMonth(AUG_04_2015_NOON_UTC_AS_DATE));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateNotSameDayOfMonth() {
-		assertThat(AUG_04_2015_NOON_AS_DATE, DateMatchers.sameDayOfMonth(AUG_01_2015_NOON_AS_DATE));
+		assertThat(AUG_04_2015_NOON_UTC_AS_DATE, DateMatchers.sameDayOfMonth(AUG_01_2015_NOON_UTC_AS_DATE));
 	}
 
 	@Test
 	public void isDateSameDayOfMonthDifferentMonth() {
-		assertThat(AUG_04_2015_NOON_AS_DATE, DateMatchers.sameDayOfMonth(SEP_04_2015_NOON_AS_DATE));
+		assertThat(AUG_04_2015_NOON_UTC_AS_DATE, DateMatchers.sameDayOfMonth(SEP_04_2015_NOON_UTC_AS_DATE));
 	}
 
 	// LocalDate Matchers

--- a/src/test/java/org/exparity/hamcrest/date/core/IsSameDayOfWeekTest.java
+++ b/src/test/java/org/exparity/hamcrest/date/core/IsSameDayOfWeekTest.java
@@ -14,22 +14,22 @@ import org.testng.annotations.Test;
  */
 public class IsSameDayOfWeekTest {
 
-    private static final String ASSERTION_PATTERN = "\\s*Expected: the date is on a [A-Za-z]*\\s*but: the date is on a [A-Za-z]*";
+    private static final String ASSERTION_PATTERN = "\\sExpected: the date is on a \\p{IsAlphabetic}+?\\s     but: the date is on a \\p{IsAlphabetic}+";
 
 	// Date Matchers
 	@Test
 	public void isDateSameDayOfWeek() {
-		assertThat(AUG_04_2015_NOON_AS_DATE, DateMatchers.sameDayOfWeek(AUG_04_2015_NOON_AS_DATE));
+		assertThat(AUG_04_2015_NOON_UTC_AS_DATE, DateMatchers.sameDayOfWeek(AUG_04_2015_NOON_UTC_AS_DATE));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateNotSameDayOfWeek() {
-		assertThat(AUG_04_2015_NOON_AS_DATE, DateMatchers.sameDayOfWeek(AUG_01_2015_NOON_AS_DATE));
+		assertThat(AUG_04_2015_NOON_UTC_AS_DATE, DateMatchers.sameDayOfWeek(AUG_01_2015_NOON_UTC_AS_DATE));
 	}
 
 	@Test
 	public void isDateSameDayOfWeekDifferentMonth() {
-		assertThat(AUG_07_2015_NOON_AS_DATE, DateMatchers.sameDayOfWeek(SEP_04_2015_NOON_AS_DATE));
+		assertThat(AUG_07_2015_NOON_UTC_AS_DATE, DateMatchers.sameDayOfWeek(SEP_04_2015_NOON_UTC_AS_DATE));
 	}
 
 	// LocalDate Matchers

--- a/src/test/java/org/exparity/hamcrest/date/core/IsSameDayTest.java
+++ b/src/test/java/org/exparity/hamcrest/date/core/IsSameDayTest.java
@@ -11,6 +11,7 @@ import org.exparity.hamcrest.date.LocalDateMatchers;
 import org.exparity.hamcrest.date.LocalDateTimeMatchers;
 import org.exparity.hamcrest.date.Months;
 import org.exparity.hamcrest.date.ZonedDateTimeMatchers;
+import org.exparity.hamcrest.date.testutils.ZoneIds;
 import org.testng.annotations.Test;
 
 /**
@@ -21,78 +22,88 @@ import org.testng.annotations.Test;
 @SuppressWarnings("deprecation")
 public class IsSameDayTest {
 
-    private static final String ASSERTION_PATTERN = "\\s*Expected: the same day as [A-Za-z0-9:,.+ ]*\\s*but: the day is [A-Za-z0-9:,.+ ]*";
+    private static final String ASSERTION_PATTERN = "\\sExpected: the same day as (?s:.)+?\\s     but: the day is (?s:.)+";
 
 	// Date Matchers
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateSameDayEarlierDate() {
-		assertThat(JUN_15_2012_11AM_AS_DATE, DateMatchers.sameDay(JUN_01_2012_11AM_AS_DATE));
+		assertThat(JUN_15_2012_11AM_UTC_AS_DATE, DateMatchers.sameDay(JUN_01_2012_11AM_UTC_AS_DATE).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateSameDayLaterDate() {
-		assertThat(JUN_15_2012_11AM_AS_DATE, DateMatchers.sameDay(JUN_01_2012_11AM_AS_DATE));
+		assertThat(JUN_15_2012_11AM_UTC_AS_DATE, DateMatchers.sameDay(JUN_01_2012_11AM_UTC_AS_DATE).atZone(UTC));
 	}
 
 	@Test
 	public void isDateSameDaySameDate() {
-		assertThat(JUN_15_2012_11AM_AS_DATE, DateMatchers.sameDay(JUN_15_2012_11AM_AS_DATE));
+		assertThat(JUN_15_2012_11AM_UTC_AS_DATE, DateMatchers.sameDay(JUN_15_2012_11AM_UTC_AS_DATE).atZone(UTC));
 	}
 
 	@Test
 	public void isDateSameDaySameDateDifferentTimeZone() {
-		assertThat(JAN_01_2012_11AM_PST_AS_DATE, DateMatchers.sameDay(JAN_01_2012_11AM_GMT_AS_DATE));
+		assertThat(JAN_01_2012_11AM_PST_AS_DATE, DateMatchers.sameDay(JAN_01_2012_11AM_GMT_AS_DATE).atZone(UTC));
+	}
+
+	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
+	public void isDateSameDayMidnightLocallyDifferentTimeZoneLowerOffsetPerspective() {
+		assertThat(JAN_01_2012_MIDNIGHT_GMT_AS_DATE, DateMatchers.sameDay(JAN_01_2012_MIDNIGHT_CET_AS_DATE).atZone(ZoneIds.GMT));
+	}
+
+	@Test
+	public void isDateSameDayMidnightLocallyDifferentTimeZoneHigherOffsetPerspective() {
+		assertThat(JAN_01_2012_MIDNIGHT_GMT_AS_DATE, DateMatchers.sameDay(JAN_01_2012_MIDNIGHT_CET_AS_DATE).atZone(ZoneIds.CET));
 	}
 
 	@Test
 	public void isDateSameDayLaterSameDateDifferentTimeZone() {
-		assertThat(JAN_01_2012_11AM_GMT_AS_DATE, DateMatchers.sameDay(JAN_01_2012_11AM_PST_AS_DATE));
+		assertThat(JAN_01_2012_11AM_GMT_AS_DATE, DateMatchers.sameDay(JAN_01_2012_11AM_PST_AS_DATE).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateSameDayEarlierLocalDate() {
-		assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.sameDay(JUN_14_2012));
+		assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.sameDay(JUN_14_2012).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateSameDayLaterLocalDate() {
-		assertThat(JUN_15_2012_11AM_AS_DATE, DateMatchers.sameDay(JUN_16_2012));
+		assertThat(JUN_15_2012_11AM_UTC_AS_DATE, DateMatchers.sameDay(JUN_16_2012).atZone(UTC));
 	}
 
 	@Test
 	public void isDateSameDaySameLocalDate() {
-		assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.sameDay(JUN_15_2012));
+		assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.sameDay(JUN_15_2012).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateSameDayEarlierDay() {
-		assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.sameDay(2012, Months.JUNE, 14));
+		assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.sameDay(2012, Months.JUNE, 14).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateSameDayLaterDay() {
-		assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.sameDay(2012, Months.JUNE, 16));
+		assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.sameDay(2012, Months.JUNE, 16).atZone(UTC));
 	}
 
 	@Test
 	public void isDateSameDaySameDay() {
-		assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.sameDay(2012, Months.JUNE, 15));
+		assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.sameDay(2012, Months.JUNE, 15).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateSameDayEarlierDayMonthYear() {
-		assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.sameDay(new DayMonthYear(14, Months.JUNE, 2012)));
+		assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.sameDay(new DayMonthYear(14, Months.JUNE, 2012)).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateSameDayLaterDayMonthYear() {
-		assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.sameDay(new DayMonthYear(16, Months.JUNE, 2012)));
+		assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.sameDay(new DayMonthYear(16, Months.JUNE, 2012)).atZone(UTC));
 	}
 
 	@Test
 	public void isDateSameDaySameDayMonthYear() {
-		assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.sameDay(new DayMonthYear(15, Months.JUNE, 2012)));
+		assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.sameDay(new DayMonthYear(15, Months.JUNE, 2012)).atZone(UTC));
 	}
 
 	// LocalDate Matchers
@@ -162,42 +173,42 @@ public class IsSameDayTest {
 	// ZonedDateTime Matchers
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isZonedDateTimeSameDayEarlierZonedDateTime() {
-		assertThat(AUG_04_2015_NOON_UTC, ZonedDateTimeMatchers.sameDay(AUG_03_2015_NOON_UTC));
+		assertThat(AUG_04_2015_NOON_UTC, ZonedDateTimeMatchers.sameDay(AUG_03_2015_NOON_UTC).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isZonedDateTimeSameDayLaterZonedDateTime() {
-		assertThat(AUG_04_2015_NOON_UTC, ZonedDateTimeMatchers.sameDay(AUG_05_2015_NOON_UTC));
+		assertThat(AUG_04_2015_NOON_UTC, ZonedDateTimeMatchers.sameDay(AUG_05_2015_NOON_UTC).atZone(UTC));
 	}
 
 	@Test
 	public void isZonedDateTimeSameDaySameZonedDateTime() {
-		assertThat(AUG_04_2015_NOON_UTC, ZonedDateTimeMatchers.sameDay(AUG_04_2015_NOON_UTC));
+		assertThat(AUG_04_2015_NOON_UTC, ZonedDateTimeMatchers.sameDay(AUG_04_2015_NOON_UTC).atZone(UTC));
 	}
 
 	@Test
 	public void isZonedDateTimeSameDayZonedDateTimeEarlierZone() {
-		assertThat(AUG_04_2015_NOON_UTC, ZonedDateTimeMatchers.sameDay(AUG_04_2015_NOON_CET));
+		assertThat(AUG_04_2015_NOON_UTC, ZonedDateTimeMatchers.sameDay(AUG_04_2015_NOON_CET).atZone(UTC));
 	}
 
 	@Test
 	public void isZonedDateTimeSameDayZonedDateTimeLaterZone() {
-		assertThat(AUG_04_2015_NOON_UTC, ZonedDateTimeMatchers.sameDay(AUG_04_2015_NOON_EST));
+		assertThat(AUG_04_2015_NOON_UTC, ZonedDateTimeMatchers.sameDay(AUG_04_2015_NOON_EST).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isZonedDateTimeSameDayEarlierDay() {
-		assertThat(AUG_04_2015_NOON_UTC, ZonedDateTimeMatchers.isDay(2015, AUGUST, 3, UTC));
+		assertThat(AUG_04_2015_NOON_UTC, ZonedDateTimeMatchers.isDay(2015, AUGUST, 3, UTC).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isZonedDateTimeSameDayLaterDay() {
-		assertThat(AUG_04_2015_NOON_UTC, ZonedDateTimeMatchers.isDay(2015, AUGUST, 5, UTC));
+		assertThat(AUG_04_2015_NOON_UTC, ZonedDateTimeMatchers.isDay(2015, AUGUST, 5, UTC).atZone(UTC));
 	}
 
 	@Test
 	public void isZonedDateTimeSameDayLaterSameDay() {
-		assertThat(AUG_04_2015_NOON_UTC, ZonedDateTimeMatchers.isDay(2015, AUGUST, 4, UTC));
+		assertThat(AUG_04_2015_NOON_UTC, ZonedDateTimeMatchers.isDay(2015, AUGUST, 4, UTC).atZone(UTC));
 	}
 
 }

--- a/src/test/java/org/exparity/hamcrest/date/core/IsSameHourOfDayTest.java
+++ b/src/test/java/org/exparity/hamcrest/date/core/IsSameHourOfDayTest.java
@@ -1,6 +1,8 @@
 package org.exparity.hamcrest.date.core;
 
 import static org.exparity.hamcrest.date.testutils.DateMatcherTestUtils.addDateField;
+import static org.exparity.hamcrest.date.testutils.Dates.JAN_01_2012_MIDNIGHT_CET_AS_DATE;
+import static org.exparity.hamcrest.date.testutils.Dates.JAN_01_2012_MIDNIGHT_GMT_AS_DATE;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.time.LocalDateTime;
@@ -13,6 +15,7 @@ import org.exparity.hamcrest.date.DateMatchers;
 import org.exparity.hamcrest.date.LocalDateTimeMatchers;
 import org.exparity.hamcrest.date.LocalTimeMatchers;
 import org.exparity.hamcrest.date.ZonedDateTimeMatchers;
+import org.exparity.hamcrest.date.testutils.ZoneIds;
 import org.testng.annotations.Test;
 
 /**
@@ -23,7 +26,7 @@ import org.testng.annotations.Test;
 @SuppressWarnings("deprecation")
 public class IsSameHourOfDayTest {
 
-    private static final String ASSERTION_PATTERN = "\\s*Expected: the date has the hour [0-9]*\\s*but: the date has the hour [0-9]*";
+    private static final String ASSERTION_PATTERN = "\\sExpected: the date has the hour [0-9]+?\\s     but: the date has the hour [0-9]+";
 
 	// Date Matchers
 	@Test
@@ -60,6 +63,16 @@ public class IsSameHourOfDayTest {
 	public void isDateSameHourOfDayDifferentDay() {
 		Date date = new Date(), other = addDateField(date, Calendar.DAY_OF_WEEK, 1);
 		assertThat(other, DateMatchers.sameHourOfDay(date));
+	}
+
+	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
+	public void isDateSameHourOfDayMidnightLocallyDifferentTimeZoneLowerOffsetPerspective() {
+		assertThat(JAN_01_2012_MIDNIGHT_GMT_AS_DATE, DateMatchers.sameHourOfDay(JAN_01_2012_MIDNIGHT_CET_AS_DATE).atZone(ZoneIds.GMT));
+	}
+
+	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
+	public void isDateSameHourOfDayMidnightLocallyDifferentTimeZoneHigherOffsetPerspective() {
+		assertThat(JAN_01_2012_MIDNIGHT_GMT_AS_DATE, DateMatchers.sameHourOfDay(JAN_01_2012_MIDNIGHT_CET_AS_DATE).atZone(ZoneIds.CET));
 	}
 
 	// LocalDateTime Matchers

--- a/src/test/java/org/exparity/hamcrest/date/core/IsSameInstantTest.java
+++ b/src/test/java/org/exparity/hamcrest/date/core/IsSameInstantTest.java
@@ -2,6 +2,7 @@ package org.exparity.hamcrest.date.core;
 
 import static java.time.Month.AUGUST;
 import static org.exparity.hamcrest.date.testutils.Dates.*;
+import static org.exparity.hamcrest.date.testutils.ZoneIds.UTC;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.time.Month;
@@ -21,78 +22,78 @@ import org.testng.annotations.Test;
 @SuppressWarnings("deprecation")
 public class IsSameInstantTest {
 
-    private static final String ASSERTION_PATTERN = "\\s*Expected: the same date as [A-Za-z0-9:,.+ \\-]*\\s*but: the date is [A-Za-z0-9:,.+ \\-]*";
+    private static final String ASSERTION_PATTERN = "\\sExpected: the same date as (?s:.)+?\\s     but: the date is (?s:.)+";
 
 	// Date Matchers
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateSameInstantEarlierDate() {
-		assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.sameInstant(JUN_15_2012_11AM_AS_DATE));
+		assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.sameInstant(JUN_15_2012_11AM_UTC_AS_DATE).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateSameInstantLaterDate() {
-		assertThat(JUN_15_2012_11AM_AS_DATE, DateMatchers.sameInstant(JUN_15_2012_11PM_AS_DATE));
+		assertThat(JUN_15_2012_11AM_UTC_AS_DATE, DateMatchers.sameInstant(JUN_15_2012_11PM_UTC_AS_DATE).atZone(UTC));
 	}
 
 	@Test
 	public void isDateSameInstantSameDate() {
-		assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.sameInstant(JUN_15_2012_11PM_AS_DATE));
+		assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.sameInstant(JUN_15_2012_11PM_UTC_AS_DATE).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateSameInstantSameDateDifferentTimeZone() {
-		assertThat(JAN_01_2012_11AM_PST_AS_DATE, DateMatchers.sameInstant(JAN_01_2012_11AM_GMT_AS_DATE));
+		assertThat(JAN_01_2012_11AM_PST_AS_DATE, DateMatchers.sameInstant(JAN_01_2012_11AM_GMT_AS_DATE).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateSameInstantLaterSameDateDifferentTimeZone() {
-		assertThat(JAN_01_2012_11AM_GMT_AS_DATE, DateMatchers.sameInstant(JAN_01_2012_11AM_PST_AS_DATE));
+		assertThat(JAN_01_2012_11AM_GMT_AS_DATE, DateMatchers.sameInstant(JAN_01_2012_11AM_PST_AS_DATE).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateSameInstantEarlierEpochTime() {
-		assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.sameInstant(JUN_15_2012_11PM_AS_DATE.getTime() + 1));
+		assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.sameInstant(JUN_15_2012_11PM_UTC_AS_DATE.getTime() + 1).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateSameInstantLaterEpochTime() {
-		assertThat(JUN_15_2012_11AM_AS_DATE, DateMatchers.sameInstant(JUN_15_2012_11PM_AS_DATE.getTime() + 1));
+		assertThat(JUN_15_2012_11AM_UTC_AS_DATE, DateMatchers.sameInstant(JUN_15_2012_11PM_UTC_AS_DATE.getTime() + 1).atZone(UTC));
 	}
 
 	@Test
 	public void isDateSameInstantSameEpochTime() {
-		assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.sameInstant(JUN_15_2012_11PM_AS_DATE.getTime()));
+		assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.sameInstant(JUN_15_2012_11PM_UTC_AS_DATE.getTime()).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateSameInstantEarlierDateValue() {
-		assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.isInstant(2012, Month.JUNE, 15, 23, 0, 0, 1));
+		assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.isInstant(2012, Month.JUNE, 15, 23, 0, 0, 1).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateSameInstantLaterDateValue() {
-		assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.isInstant(2012, Month.JUNE, 15, 22, 59, 59, 59));
+		assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.isInstant(2012, Month.JUNE, 15, 22, 59, 59, 59).atZone(UTC));
 	}
 
 	@Test
 	public void isDateSameInstantSameDateValue() {
-		assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.isInstant(2012, Month.JUNE, 15, 23, 0, 0, 0));
+		assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.isInstant(2012, Month.JUNE, 15, 23, 0, 0, 0).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateSameInstantEarlierDeprecatedDateValue() {
-		assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.sameInstant(2012, Months.JUNE, 15, 23, 0, 0, 1));
+		assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.sameInstant(2012, Months.JUNE, 15, 23, 0, 0, 1).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateSameInstantLaterDeprecatedDateValue() {
-		assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.sameInstant(2012, Months.JUNE, 15, 22, 59, 59, 59));
+		assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.sameInstant(2012, Months.JUNE, 15, 22, 59, 59, 59).atZone(UTC));
 	}
 
 	@Test
 	public void isDateSameInstantSameDeprecatedDateValue() {
-		assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.sameInstant(2012, Months.JUNE, 15, 23, 0, 0, 0));
+		assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.sameInstant(2012, Months.JUNE, 15, 23, 0, 0, 0).atZone(UTC));
 	}
 
 	// LocalDateTime Matchers

--- a/src/test/java/org/exparity/hamcrest/date/core/IsSameMillisecondOfSecondTest.java
+++ b/src/test/java/org/exparity/hamcrest/date/core/IsSameMillisecondOfSecondTest.java
@@ -17,7 +17,7 @@ import org.testng.annotations.Test;
 @SuppressWarnings("deprecation")
 public class IsSameMillisecondOfSecondTest {
 
-    private static final String ASSERTION_PATTERN = "\\s*Expected: the date has the millisecond [0-9]*\\s*but: the date has the millisecond [0-9]*";
+    private static final String ASSERTION_PATTERN = "\\sExpected: the date has the millisecond [0-9]+?\\s     but: the date has the millisecond [0-9]+";
 
 	// Date Matchers
 	@Test

--- a/src/test/java/org/exparity/hamcrest/date/core/IsSameMinuteOfHourTest.java
+++ b/src/test/java/org/exparity/hamcrest/date/core/IsSameMinuteOfHourTest.java
@@ -23,7 +23,7 @@ import org.testng.annotations.Test;
 @SuppressWarnings("deprecation")
 public class IsSameMinuteOfHourTest {
 
-    private static final String ASSERTION_PATTERN = "\\s*Expected: the date has the minute [0-9]*\\s*but: the date has the minute [0-9]*";
+    private static final String ASSERTION_PATTERN = "\\sExpected: the date has the minute [0-9]+?\\s     but: the date has the minute [0-9]+";
 
 	// Date Matchers
 	@Test

--- a/src/test/java/org/exparity/hamcrest/date/core/IsSameMonthOfYearTest.java
+++ b/src/test/java/org/exparity/hamcrest/date/core/IsSameMonthOfYearTest.java
@@ -21,7 +21,7 @@ import org.testng.annotations.Test;
 @SuppressWarnings("deprecation")
 public class IsSameMonthOfYearTest {
 
-    private static final String ASSERTION_PATTERN = "\\s*Expected: the date is in [A-Za-z]*\\s*but: the date is in [A-Za-z]*";
+    private static final String ASSERTION_PATTERN = "\\sExpected: the date has the month [0-9]+?\\s     but: the date has the month [0-9]+?";
 
 	// Date Matchers
 	@Test

--- a/src/test/java/org/exparity/hamcrest/date/core/IsSameOrAfterTest.java
+++ b/src/test/java/org/exparity/hamcrest/date/core/IsSameOrAfterTest.java
@@ -3,6 +3,7 @@ package org.exparity.hamcrest.date.core;
 import static java.time.Month.AUGUST;
 import static org.exparity.hamcrest.date.ZonedDateTimeMatchers.sameOrAfter;
 import static org.exparity.hamcrest.date.testutils.Dates.*;
+import static org.exparity.hamcrest.date.testutils.ZoneIds.UTC;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.time.LocalTime;
@@ -25,93 +26,93 @@ import org.testng.annotations.Test;
 @SuppressWarnings("deprecation")
 public class IsSameOrAfterTest {
 
-    private static final String ASSERTION_PATTERN = "\\s*Expected: the date is on the same date or after [A-Za-z0-9:,.+\\- ]*\\s*but: the date is [A-Za-z0-9:,.+\\- ]*";
+    private static final String ASSERTION_PATTERN = "\\sExpected: the date is on the same date or after (?s:.)+?\\s     but: the date is (?s:.)+";
 
 	// Date Matchers
 
 	@Test
 	public void isDateSameOrAfterEarlierDate() {
-		assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.sameOrAfter(JUN_15_2012_11AM_AS_DATE));
+		assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.sameOrAfter(JUN_15_2012_11AM_UTC_AS_DATE).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateSameOrAfterLaterDate() {
-		assertThat(JUN_15_2012_11AM_AS_DATE, DateMatchers.sameOrAfter(JUN_15_2012_11PM_AS_DATE));
+		assertThat(JUN_15_2012_11AM_UTC_AS_DATE, DateMatchers.sameOrAfter(JUN_15_2012_11PM_UTC_AS_DATE).atZone(UTC));
 	}
 
 	@Test
 	public void isDateSameOrAfterSameDate() {
-		assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.sameOrAfter(JUN_15_2012_11PM_AS_DATE));
+		assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.sameOrAfter(JUN_15_2012_11PM_UTC_AS_DATE).atZone(UTC));
 	}
 
 	@Test
 	public void isDateSameOrAfterSameDateEarlierZone() {
-		assertThat(JAN_01_2012_11AM_PST_AS_DATE, DateMatchers.sameOrAfter(JAN_01_2012_11AM_GMT_AS_DATE));
+		assertThat(JAN_01_2012_11AM_PST_AS_DATE, DateMatchers.sameOrAfter(JAN_01_2012_11AM_GMT_AS_DATE).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateSameOrAfterSameDateLaterZone() {
-		assertThat(JAN_01_2012_11AM_GMT_AS_DATE, DateMatchers.sameOrAfter(JAN_01_2012_11AM_PST_AS_DATE));
+		assertThat(JAN_01_2012_11AM_GMT_AS_DATE, DateMatchers.sameOrAfter(JAN_01_2012_11AM_PST_AS_DATE).atZone(UTC));
 	}
 
 	@Test
 	public void isDateSameOrAfterEarlierLocalDate() {
-		assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.sameOrAfter(JUN_14_2012));
+		assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.sameOrAfter(JUN_14_2012).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateSameOrAfterLaterLocalDate() {
-		assertThat(JUN_15_2012_11AM_AS_DATE, DateMatchers.sameOrAfter(JUN_16_2012));
+		assertThat(JUN_15_2012_11AM_UTC_AS_DATE, DateMatchers.sameOrAfter(JUN_16_2012).atZone(UTC));
 	}
 
 	@Test
 	public void isDateSameOrAfterSameLocalDate() {
-		assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.sameOrAfter(JUN_15_2012));
+		assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.sameOrAfter(JUN_15_2012).atZone(UTC));
 	}
 
 	@Test
 	public void isDateSameOrAfterEarlierDay() {
-		assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.sameOrAfter(2012, Months.JUNE, 14));
+		assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.sameOrAfter(2012, Months.JUNE, 14).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateSameOrAfterLaterDay() {
-		assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.sameOrAfter(2012, Months.JUNE, 16));
+		assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.sameOrAfter(2012, Months.JUNE, 16).atZone(UTC));
 	}
 
 	@Test
 	public void isDateSameOrAfterSameDay() {
-		assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.sameOrAfter(2012, Months.JUNE, 15));
+		assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.sameOrAfter(2012, Months.JUNE, 15).atZone(UTC));
 	}
 
 	@Test
 	public void isDateSameOrAfterEarlierDayMonthYear() {
-		assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.sameOrAfter(new DayMonthYear(14, Months.JUNE, 2012)));
+		assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.sameOrAfter(new DayMonthYear(14, Months.JUNE, 2012)).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateSameOrAfterLaterDayMonthYear() {
-		assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.sameOrAfter(new DayMonthYear(16, Months.JUNE, 2012)));
+		assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.sameOrAfter(new DayMonthYear(16, Months.JUNE, 2012)).atZone(UTC));
 	}
 
 	@Test
 	public void isDateSameOrAfterSameDayMonthYear() {
-		assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.sameOrAfter(new DayMonthYear(15, Months.JUNE, 2012)));
+		assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.sameOrAfter(new DayMonthYear(15, Months.JUNE, 2012)).atZone(UTC));
 	}
 
 	@Test
 	public void isDateSameOrAfterEarlierDateTime() {
-		assertThat(JUN_15_2012_11AM_AS_DATE, DateMatchers.sameOrAfter(2012, Months.JUNE, 15, 10, 59, 59));
+		assertThat(JUN_15_2012_11AM_UTC_AS_DATE, DateMatchers.sameOrAfter(2012, Months.JUNE, 15, 10, 59, 59).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateSameOrAfterLaterDateTime() {
-		assertThat(JUN_15_2012_11AM_AS_DATE, DateMatchers.sameOrAfter(2012, Months.JUNE, 15, 11, 00, 01));
+		assertThat(JUN_15_2012_11AM_UTC_AS_DATE, DateMatchers.sameOrAfter(2012, Months.JUNE, 15, 11, 0, 1).atZone(UTC));
 	}
 
 	@Test
 	public void isDateSameOrAfterSameDateTime() {
-		assertThat(JUN_15_2012_11AM_AS_DATE, DateMatchers.sameOrAfter(2012, Months.JUNE, 15, 11, 00, 00));
+		assertThat(JUN_15_2012_11AM_UTC_AS_DATE, DateMatchers.sameOrAfter(2012, Months.JUNE, 15, 11, 0, 0).atZone(UTC));
 	}
 
 	// LocalDate Matchers

--- a/src/test/java/org/exparity/hamcrest/date/core/IsSameOrBeforeTest.java
+++ b/src/test/java/org/exparity/hamcrest/date/core/IsSameOrBeforeTest.java
@@ -3,6 +3,7 @@ package org.exparity.hamcrest.date.core;
 import static java.time.Month.AUGUST;
 import static org.exparity.hamcrest.date.ZonedDateTimeMatchers.sameOrBefore;
 import static org.exparity.hamcrest.date.testutils.Dates.*;
+import static org.exparity.hamcrest.date.testutils.ZoneIds.UTC;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.time.LocalTime;
@@ -25,93 +26,93 @@ import org.testng.annotations.Test;
 @SuppressWarnings("deprecation")
 public class IsSameOrBeforeTest {
 
-    private static final String ASSERTION_PATTERN = "\\s*Expected: the date is on the same date or before [A-Za-z0-9:,.+ ]*\\s*but: the date is [A-Za-z0-9:,.+ ]*";
+    private static final String ASSERTION_PATTERN = "\\sExpected: the date is on the same date or before (?s:.)+?\\s     but: the date is (?s:.)+";
 
 	// Date Matchers
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateSameOrBeforeLaterDate() {
-		assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.sameOrBefore(JUN_15_2012_11AM_AS_DATE));
+		assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.sameOrBefore(JUN_15_2012_11AM_UTC_AS_DATE).atZone(UTC));
 	}
 
 	@Test
 	public void isDateSameOrBeforeDate() {
-		assertThat(JUN_15_2012_11AM_AS_DATE, DateMatchers.sameOrBefore(JUN_15_2012_11PM_AS_DATE));
+		assertThat(JUN_15_2012_11AM_UTC_AS_DATE, DateMatchers.sameOrBefore(JUN_15_2012_11PM_UTC_AS_DATE).atZone(UTC));
 	}
 
 	@Test
 	public void isDateSameOrBeforeSameDate() {
-		assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.sameOrBefore(JUN_15_2012_11PM_AS_DATE));
+		assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.sameOrBefore(JUN_15_2012_11PM_UTC_AS_DATE).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateSameOrBeforeDateLaterTimeZone() {
-		assertThat(JAN_01_2012_11AM_PST_AS_DATE, DateMatchers.sameOrBefore(JAN_01_2012_11AM_GMT_AS_DATE));
+		assertThat(JAN_01_2012_11AM_PST_AS_DATE, DateMatchers.sameOrBefore(JAN_01_2012_11AM_GMT_AS_DATE).atZone(UTC));
 	}
 
 	@Test
 	public void isDateSameOrBeforeDateEarlierTimeZone() {
-		assertThat(JAN_01_2012_11AM_GMT_AS_DATE, DateMatchers.sameOrBefore(JAN_01_2012_11AM_PST_AS_DATE));
+		assertThat(JAN_01_2012_11AM_GMT_AS_DATE, DateMatchers.sameOrBefore(JAN_01_2012_11AM_PST_AS_DATE).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateSameOrBeforeLaterLocalDate() {
-		assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.sameOrBefore(JUN_14_2012));
+		assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.sameOrBefore(JUN_14_2012).atZone(UTC));
 	}
 
 	@Test
 	public void isDateSameOrBeforeLocalDate() {
-		assertThat(JUN_15_2012_11AM_AS_DATE, DateMatchers.sameOrBefore(JUN_16_2012));
+		assertThat(JUN_15_2012_11AM_UTC_AS_DATE, DateMatchers.sameOrBefore(JUN_16_2012).atZone(UTC));
 	}
 
 	@Test
 	public void isDateSameOrBeforeSameLocalDate() {
-		assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.sameOrBefore(JUN_15_2012));
+		assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.sameOrBefore(JUN_15_2012).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateSameOrBeforeLaterDay() {
-		assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.sameOrBefore(2012, Months.JUNE, 14));
+		assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.sameOrBefore(2012, Months.JUNE, 14).atZone(UTC));
 	}
 
 	@Test
 	public void isDateSameOrBeforeDay() {
-		assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.sameOrBefore(2012, Months.JUNE, 16));
+		assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.sameOrBefore(2012, Months.JUNE, 16).atZone(UTC));
 	}
 
 	@Test
 	public void isDateSameOrBeforeSameDay() {
-		assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.sameOrBefore(2012, Months.JUNE, 15));
+		assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.sameOrBefore(2012, Months.JUNE, 15).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateSameOrBeforeLaterDayMonthYear() {
-		assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.sameOrBefore(new DayMonthYear(14, Months.JUNE, 2012)));
+		assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.sameOrBefore(new DayMonthYear(14, Months.JUNE, 2012)).atZone(UTC));
 	}
 
 	@Test
 	public void isDateSameOrBeforeDayMonthYear() {
-		assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.sameOrBefore(new DayMonthYear(16, Months.JUNE, 2012)));
+		assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.sameOrBefore(new DayMonthYear(16, Months.JUNE, 2012)).atZone(UTC));
 	}
 
 	@Test
 	public void isDateSameOrBeforeSameDayMonthYear() {
-		assertThat(JUN_15_2012_11PM_AS_DATE, DateMatchers.sameOrBefore(new DayMonthYear(15, Months.JUNE, 2012)));
+		assertThat(JUN_15_2012_11PM_UTC_AS_DATE, DateMatchers.sameOrBefore(new DayMonthYear(15, Months.JUNE, 2012)).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateSameOrBeforeLaterDateTime() {
-		assertThat(JUN_15_2012_11AM_AS_DATE, DateMatchers.sameOrBefore(2012, Months.JUNE, 15, 10, 59, 59));
+		assertThat(JUN_15_2012_11AM_UTC_AS_DATE, DateMatchers.sameOrBefore(2012, Months.JUNE, 15, 10, 59, 59).atZone(UTC));
 	}
 
 	@Test
 	public void isDateSameOrBeforeDateTime() {
-		assertThat(JUN_15_2012_11AM_AS_DATE, DateMatchers.sameOrBefore(2012, Months.JUNE, 15, 11, 00, 01));
+		assertThat(JUN_15_2012_11AM_UTC_AS_DATE, DateMatchers.sameOrBefore(2012, Months.JUNE, 15, 11, 0, 1).atZone(UTC));
 	}
 
 	@Test
 	public void isDateSameOrBeforeSameDateTime() {
-		assertThat(JUN_15_2012_11AM_AS_DATE, DateMatchers.sameOrBefore(2012, Months.JUNE, 15, 11, 00, 00));
+		assertThat(JUN_15_2012_11AM_UTC_AS_DATE, DateMatchers.sameOrBefore(2012, Months.JUNE, 15, 11, 0, 0).atZone(UTC));
 	}
 
 	// LocalDate Matchers

--- a/src/test/java/org/exparity/hamcrest/date/core/IsSameSecondOfMinuteTest.java
+++ b/src/test/java/org/exparity/hamcrest/date/core/IsSameSecondOfMinuteTest.java
@@ -23,7 +23,7 @@ import org.testng.annotations.Test;
 @SuppressWarnings("deprecation")
 public class IsSameSecondOfMinuteTest {
 
-    private static final String ASSERTION_PATTERN = "\\s*Expected: the date has the second [0-9]*\\s*but: the date has the second [0-9]*";
+    private static final String ASSERTION_PATTERN = "\\sExpected: the date has the second [0-9]+?\\s     but: the date has the second [0-9]+";
 
 	// Date Matchers
 	@Test

--- a/src/test/java/org/exparity/hamcrest/date/core/IsSameYearTest.java
+++ b/src/test/java/org/exparity/hamcrest/date/core/IsSameYearTest.java
@@ -20,7 +20,7 @@ import org.testng.annotations.Test;
  */
 public class IsSameYearTest {
 
-    private static final String ASSERTION_PATTERN = "\\s*Expected: the date is in the year [0-9]*\\s*but: the date has the year [0-9]*";
+    private static final String ASSERTION_PATTERN = "\\sExpected: the date has the year [0-9]+?\\s     but: the date has the year [0-9]+";
 
 	// Date Matchers
 	@Test

--- a/src/test/java/org/exparity/hamcrest/date/core/IsSecondTest.java
+++ b/src/test/java/org/exparity/hamcrest/date/core/IsSecondTest.java
@@ -1,7 +1,7 @@
 package org.exparity.hamcrest.date.core;
 
 import static org.exparity.hamcrest.date.testutils.Dates.AUG_04_2015_NOON;
-import static org.exparity.hamcrest.date.testutils.Dates.AUG_04_2015_NOON_AS_DATE;
+import static org.exparity.hamcrest.date.testutils.Dates.AUG_04_2015_NOON_UTC_AS_DATE;
 import static org.exparity.hamcrest.date.testutils.Dates.AUG_04_2015_NOON_UTC;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -14,34 +14,34 @@ import org.exparity.hamcrest.date.ZonedDateTimeMatchers;
 import org.testng.annotations.Test;
 
 /**
- * Unit Tests for the {@link IsSameSecondOfDay} class
+ * Unit Tests for the {@link IsSecond} class
  *
  * @author Stewart Bissett
  */
 @SuppressWarnings("deprecation")
 public class IsSecondTest {
 
-    private static final String ASSERTION_PATTERN = "\\s*Expected: the date has the second [0-9]*\\s*but: the date has the second [0-9]*";
+    private static final String ASSERTION_PATTERN = "\\sExpected: the date has the second [0-9]+?\\s     but: the date has the second [0-9]+";
 
     // Date Matchers
     @Test
     public void isDateSecond() {
-        assertThat(AUG_04_2015_NOON_AS_DATE, DateMatchers.isSecond(0));
+        assertThat(AUG_04_2015_NOON_UTC_AS_DATE, DateMatchers.isSecond(0));
     }
 
     @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
     public void isDateNotSecond() {
-        assertThat(AUG_04_2015_NOON_AS_DATE, DateMatchers.isSecond(1));
+        assertThat(AUG_04_2015_NOON_UTC_AS_DATE, DateMatchers.isSecond(1));
     }
 
     @Test
     public void isDateSameSecond() {
-        assertThat(AUG_04_2015_NOON_AS_DATE, DateMatchers.sameSecond(0));
+        assertThat(AUG_04_2015_NOON_UTC_AS_DATE, DateMatchers.sameSecond(0));
     }
 
     @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
     public void isDateNotSameSecond() {
-        assertThat(AUG_04_2015_NOON_AS_DATE, DateMatchers.sameSecond(1));
+        assertThat(AUG_04_2015_NOON_UTC_AS_DATE, DateMatchers.sameSecond(1));
     }
 
     // LocalDateTime Matchers

--- a/src/test/java/org/exparity/hamcrest/date/core/IsWithinTest.java
+++ b/src/test/java/org/exparity/hamcrest/date/core/IsWithinTest.java
@@ -1,6 +1,7 @@
 package org.exparity.hamcrest.date.core;
 
 import static org.exparity.hamcrest.date.testutils.Dates.*;
+import static org.exparity.hamcrest.date.testutils.ZoneIds.UTC;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.time.LocalTime;
@@ -16,97 +17,97 @@ import org.exparity.hamcrest.date.testutils.ZoneIds;
 import org.testng.annotations.Test;
 
 /**
- * Unit Tests for the {@link IsSameYear} class
+ * Unit Tests for the {@link IsWithin} class
  *
  * @author Stewart Bissett
  */
 public class IsWithinTest {
 
-    private static final String ASSERTION_PATTERN = "\\s*Expected: the date is within [0-9]* [a-z]* of [A-Za-z0-9:,.+ ]*\\s*but: the date is [A-Za-z0-9:,.+ ]* and [0-9]* [a-z]* different";
+    private static final String ASSERTION_PATTERN = "\\sExpected: the date is within [0-9]+? [\\w ]+? of (?s:.)+?\\s     but: the date is (?s:.)+? and [0-9]+? [\\w ]+? different";
 
 	// Date Matchers
 	@Test
 	public void isDateWithinSameDate() {
-		assertThat(AUG_04_2015_NOON_AS_DATE, DateMatchers.within(2, ChronoUnit.DAYS, AUG_04_2015_NOON_AS_DATE));
+		assertThat(AUG_04_2015_NOON_UTC_AS_DATE, DateMatchers.within(2, ChronoUnit.DAYS, AUG_04_2015_NOON_UTC_AS_DATE).atZone(UTC));
 	}
 
 	@Test
 	public void isDateWithinDateInsideLimit() {
-		assertThat(AUG_04_2015_NOON_AS_DATE, DateMatchers.within(2, ChronoUnit.DAYS, AUG_05_2015_NOON_AS_DATE));
+		assertThat(AUG_04_2015_NOON_UTC_AS_DATE, DateMatchers.within(2, ChronoUnit.DAYS, AUG_05_2015_NOON_UTC_AS_DATE).atZone(UTC));
 	}
 
 	@Test
 	public void isDateWithinDateEqualLimit() {
-		assertThat(AUG_04_2015_NOON_AS_DATE, DateMatchers.within(2, ChronoUnit.DAYS, AUG_06_2015_NOON_AS_DATE));
+		assertThat(AUG_04_2015_NOON_UTC_AS_DATE, DateMatchers.within(2, ChronoUnit.DAYS, AUG_06_2015_NOON_UTC_AS_DATE).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateWithinDateOutsideLimit() {
-		assertThat(AUG_04_2015_NOON_AS_DATE, DateMatchers.within(2, ChronoUnit.DAYS, AUG_07_2015_NOON_AS_DATE));
+		assertThat(AUG_04_2015_NOON_UTC_AS_DATE, DateMatchers.within(2, ChronoUnit.DAYS, AUG_07_2015_NOON_UTC_AS_DATE).atZone(UTC));
 	}
 
 	@Test
 	public void isDateWithinSameLocalDate() {
-		assertThat(AUG_04_2015_NOON_AS_DATE, DateMatchers.within(2, ChronoUnit.DAYS, AUG_04_2015));
+		assertThat(AUG_04_2015_NOON_UTC_AS_DATE, DateMatchers.within(2, ChronoUnit.DAYS, AUG_04_2015).atZone(UTC));
 	}
 
 	@Test
 	public void isDateWithinLocalDateInsideLimit() {
-		assertThat(AUG_04_2015_NOON_AS_DATE, DateMatchers.within(2, ChronoUnit.DAYS, AUG_05_2015));
+		assertThat(AUG_04_2015_NOON_UTC_AS_DATE, DateMatchers.within(2, ChronoUnit.DAYS, AUG_05_2015).atZone(UTC));
 	}
 
 	@Test
 	public void isDateWithinLocalDateEqualLimit() {
-		assertThat(AUG_04_2015_NOON_AS_DATE, DateMatchers.within(2, ChronoUnit.DAYS, AUG_06_2015));
+		assertThat(AUG_04_2015_NOON_UTC_AS_DATE, DateMatchers.within(2, ChronoUnit.DAYS, AUG_06_2015).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateWithinLocalDateOutsideLimit() {
-		assertThat(AUG_04_2015_NOON_AS_DATE, DateMatchers.within(2, ChronoUnit.DAYS, AUG_07_2015));
+		assertThat(AUG_04_2015_NOON_UTC_AS_DATE, DateMatchers.within(2, ChronoUnit.DAYS, AUG_07_2015).atZone(UTC));
 	}
 
 	@Test
 	public void isDateWithinSameDayMonthYear() {
-		assertThat(AUG_04_2015_NOON_AS_DATE, DateMatchers.within(2, ChronoUnit.DAYS, 2015, Month.AUGUST, 4));
+		assertThat(AUG_04_2015_NOON_UTC_AS_DATE, DateMatchers.within(2, ChronoUnit.DAYS, 2015, Month.AUGUST, 4).atZone(UTC));
 	}
 
 	@Test
 	public void isDateWithinDayMonthYearInsideLimit() {
-		assertThat(AUG_04_2015_NOON_AS_DATE, DateMatchers.within(2, ChronoUnit.DAYS, 2015, Month.AUGUST, 5));
+		assertThat(AUG_04_2015_NOON_UTC_AS_DATE, DateMatchers.within(2, ChronoUnit.DAYS, 2015, Month.AUGUST, 5).atZone(UTC));
 	}
 
 	@Test
 	public void isDateWithinDayMonthYearEqualLimit() {
-		assertThat(AUG_04_2015_NOON_AS_DATE, DateMatchers.within(2, ChronoUnit.DAYS, 2015, Month.AUGUST, 6));
+		assertThat(AUG_04_2015_NOON_UTC_AS_DATE, DateMatchers.within(2, ChronoUnit.DAYS, 2015, Month.AUGUST, 6).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateWithinDayMonthYearOutsideLimit() {
-		assertThat(AUG_04_2015_NOON_AS_DATE, DateMatchers.within(2, ChronoUnit.DAYS, 2015, Month.AUGUST, 7));
+		assertThat(AUG_04_2015_NOON_UTC_AS_DATE, DateMatchers.within(2, ChronoUnit.DAYS, 2015, Month.AUGUST, 7).atZone(UTC));
 	}
 
 	@Test
 	public void isDateWithinSameDayMonthYearTime() {
-		assertThat(AUG_04_2015_NOON_AS_DATE,
-				DateMatchers.within(2, ChronoUnit.MILLIS, 2015, Month.AUGUST, 4, 12, 0, 0, 0));
+		assertThat(AUG_04_2015_NOON_UTC_AS_DATE,
+				DateMatchers.within(2, ChronoUnit.MILLIS, 2015, Month.AUGUST, 4, 12, 0, 0, 0).atZone(UTC));
 	}
 
 	@Test
 	public void isDateWithinDayMonthYearTimeInsideLimit() {
-		assertThat(AUG_04_2015_NOON_AS_DATE,
-				DateMatchers.within(2, ChronoUnit.MILLIS, 2015, Month.AUGUST, 4, 12, 0, 0, 1));
+		assertThat(AUG_04_2015_NOON_UTC_AS_DATE,
+				DateMatchers.within(2, ChronoUnit.MILLIS, 2015, Month.AUGUST, 4, 12, 0, 0, 1).atZone(UTC));
 	}
 
 	@Test
 	public void isDateWithinDayMonthYearTimeEqualLimit() {
-		assertThat(AUG_04_2015_NOON_AS_DATE,
-				DateMatchers.within(2, ChronoUnit.MILLIS, 2015, Month.AUGUST, 4, 12, 0, 0, 2));
+		assertThat(AUG_04_2015_NOON_UTC_AS_DATE,
+				DateMatchers.within(2, ChronoUnit.MILLIS, 2015, Month.AUGUST, 4, 12, 0, 0, 2).atZone(UTC));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateWithinDayMonthYearTimeOutsideLimit() {
-		assertThat(AUG_04_2015_NOON_AS_DATE,
-				DateMatchers.within(2, ChronoUnit.MILLIS, 2015, Month.AUGUST, 4, 12, 0, 0, 3));
+		assertThat(AUG_04_2015_NOON_UTC_AS_DATE,
+				DateMatchers.within(2, ChronoUnit.MILLIS, 2015, Month.AUGUST, 4, 12, 0, 0, 3).atZone(UTC));
 	}
 
 	// LocalDate Matchers

--- a/src/test/java/org/exparity/hamcrest/date/core/IsYearTest.java
+++ b/src/test/java/org/exparity/hamcrest/date/core/IsYearTest.java
@@ -17,17 +17,17 @@ import org.testng.annotations.Test;
  */
 public class IsYearTest {
 
-    private static final String ASSERTION_PATTERN = "\\s*Expected: the date is in the year [0-9]*\\s*but: the date has the year [0-9]*";
+    private static final String ASSERTION_PATTERN = "\\sExpected: the date has the year [0-9]+?\\s     but: the date has the year [0-9]+";
 
 	// Date Matchers
 	@Test
 	public void isDateYear() {
-		assertThat(AUG_04_2016_AS_DATE, DateMatchers.isYear(2016));
+		assertThat(AUG_04_2016_MIDNIGHT_UTC_AS_DATE, DateMatchers.isYear(2016));
 	}
 
 	@Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = ASSERTION_PATTERN)
 	public void isDateNotYear() {
-		assertThat(AUG_04_2015_NOON_AS_DATE, DateMatchers.isYear(2016));
+		assertThat(AUG_04_2015_NOON_UTC_AS_DATE, DateMatchers.isYear(2016));
 	}
 
 	// LocalDate Matchers

--- a/src/test/java/org/exparity/hamcrest/date/core/format/DateFormatterTest.java
+++ b/src/test/java/org/exparity/hamcrest/date/core/format/DateFormatterTest.java
@@ -15,13 +15,13 @@ public class DateFormatterTest {
 
     @Test
     public void canDescribe() {
-        String description = new DateFormatter().describe(Dates.AUG_04_2015_1159_AS_DATE);
+        String description = new DateFormatter().describe(Dates.AUG_04_2015_1159_DEFAULT_AS_DATE);
         assertThat(description, Matchers.equalTo("Tue, 04 Aug 2015 11:59:00.000 AM"));
     }
 
     @Test
     public void canDescribeDate() {
-        String description = new DateFormatter().describeDate(Dates.AUG_04_2015_1159_AS_DATE);
+        String description = new DateFormatter().describeDate(Dates.AUG_04_2015_1159_DEFAULT_AS_DATE);
         assertThat(description, Matchers.equalTo("Tue, 04 Aug 2015"));
     }
 

--- a/src/test/java/org/exparity/hamcrest/date/testutils/Dates.java
+++ b/src/test/java/org/exparity/hamcrest/date/testutils/Dates.java
@@ -1,16 +1,14 @@
 
 package org.exparity.hamcrest.date.testutils;
 
+import static java.time.LocalTime.MIDNIGHT;
 import static java.time.LocalTime.NOON;
 import static org.exparity.dates.en.FluentDateTime.*;
 import static org.exparity.hamcrest.date.testutils.TimeZones.*;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.Month;
-import java.time.ZonedDateTime;
+import java.time.*;
 import java.util.Date;
+import java.util.TimeZone;
 
 import org.exparity.dates.en.FluentDate;
 
@@ -22,72 +20,72 @@ import org.exparity.dates.en.FluentDate;
 public abstract class Dates {
 
 	// Date
-	public static final Date JAN_01_2000_11AM_AS_DATE = JAN(1, 2000).at(11);
-	public static final Date JAN_01_2012_11AM_AS_DATE = JAN(1, 2012).at(11);
-	public static final Date JAN_01_2012_11PM_AS_DATE = JAN(1, 2012).at(23);
-	public static final Date JAN_02_2012_11AM_AS_DATE = JAN(2, 2012).at(11);
-	public static final Date JAN_03_2012_11AM_AS_DATE = JAN(3, 2012).at(11);
-	public static final Date JAN_04_2012_11AM_AS_DATE = JAN(4, 2012).at(11);
-	public static final Date JAN_05_2012_11AM_AS_DATE = JAN(5, 2012).at(11);
-	public static final Date JAN_06_2012_11AM_AS_DATE = JAN(6, 2012).at(11);
-	public static final Date JAN_07_2012_11AM_AS_DATE = JAN(7, 2012).at(11);
-	public static final Date JAN_08_2012_11AM_AS_DATE = JAN(8, 2012).at(11);
-	public static final Date JAN_31_2012_11AM_AS_DATE = JAN(31, 2012).at(11);
-	public static final Date FEB_01_2012_11AM_AS_DATE = FEB(1, 2012).at(11);
-	public static final Date MAR_01_2012_11AM_AS_DATE = MAR(1, 2012).at(11);
-	public static final Date APR_01_2012_11AM_AS_DATE = APR(1, 2012).at(11);
-	public static final Date MAY_01_2012_11AM_AS_DATE = MAY(1, 2012).at(11);
-	public static final Date JUN_01_2012_11AM_AS_DATE = JUN(1, 2012).at(11);
-	public static final Date JUN_15_2012_11AM_AS_DATE = JUN(15, 2012).at(11);
-	public static final Date JUN_15_2012_11PM_AS_DATE = JUN(15, 2012).at(23);
-	public static final Date JUL_01_2012_11AM_AS_DATE = JUL(1, 2012).at(11);
-	public static final Date AUG_01_2012_11AM_AS_DATE = AUG(1, 2012).at(11);
-	public static final Date SEP_01_2012_11AM_AS_DATE = SEP(1, 2012).at(11);
-	public static final Date OCT_01_2012_11AM_AS_DATE = OCT(1, 2012).at(11);
-	public static final Date NOV_01_2012_11AM_AS_DATE = NOV(1, 2012).at(11);
-	public static final Date DEC_01_2012_11AM_AS_DATE = DEC(1, 2012).at(11);
-	public static final Date JAN_01_2013_11AM_AS_DATE = JAN(1, 2013).at(11);
-	public static final Date JAN_01_2100_11AM_AS_DATE = JAN(1, 2100).at(11);
-	public static final Date JAN_01_2015_NOON_AS_DATE = JAN(1, 2015).at(12);
-	public static final Date FEB_01_2015_NOON_AS_DATE = FEB(1, 2015).at(12);
-	public static final Date MAR_01_2015_NOON_AS_DATE = MAR(1, 2015).at(12);
-	public static final Date APR_01_2015_NOON_AS_DATE = APR(1, 2015).at(12);
-	public static final Date MAY_01_2015_NOON_AS_DATE = MAY(1, 2015).at(12);
-	public static final Date JUN_01_2015_NOON_AS_DATE = JUN(1, 2015).at(12);
-	public static final Date JUL_01_2015_NOON_AS_DATE = JUL(1, 2015).at(12);
-	public static final Date AUG_01_2015_NOON_AS_DATE = AUG(1, 2015).at(12);
-	public static final Date AUG_03_2015_NOON_AS_DATE = AUG(3, 2015).at(12);
-	public static final Date AUG_04_2015_1159_AS_DATE = AUG(4, 2015).at(11, 59);
-	public static final Date AUG_04_2015_NOON_AS_DATE = AUG(4, 2015).at(12);
-	public static final Date AUG_04_2015_1201_AS_DATE = AUG(4, 2015).at(12, 1);
-	public static final Date AUG_05_2015_NOON_AS_DATE = AUG(5, 2015).at(12);
-	public static final Date AUG_06_2015_NOON_AS_DATE = AUG(6, 2015).at(12);
-	public static final Date AUG_07_2015_NOON_AS_DATE = AUG(7, 2015).at(12);
-	public static final Date AUG_31_2015_NOON_AS_DATE = AUG(31, 2015).at(12);
-	public static final Date SEP_04_2015_NOON_AS_DATE = SEP(4, 2015).at(12);
-	public static final Date SEP_01_2015_NOON_AS_DATE = SEP(1, 2015).at(12);
-	public static final Date OCT_01_2015_NOON_AS_DATE = OCT(1, 2015).at(12);
-	public static final Date NOV_01_2015_NOON_AS_DATE = NOV(1, 2015).at(12);
-	public static final Date DEC_01_2015_NOON_AS_DATE = DEC(1, 2015).at(12);
-	public static final Date AUG_04_2016_NOON_AS_DATE = AUG(4, 2016).at(12);
-	public static final Date AUG_03_2015_AS_DATE = FluentDate.AUG(3, 2015);
-	public static final Date AUG_05_2015_AS_DATE = FluentDate.AUG(5, 2015);
-	public static final Date SEP_04_2015_AS_DATE = FluentDate.SEP(4, 2015);
-	public static final Date AUG_04_2016_AS_DATE = FluentDate.AUG(4, 2016);
+	public static final Date JAN_01_2000_11AM_UTC_AS_DATE = JAN(1, 2000).at(11, TimeZones.UTC_AS_TZ);
+	public static final Date JAN_01_2012_11AM_UTC_AS_DATE = JAN(1, 2012).at(11, TimeZones.UTC_AS_TZ);
+	public static final Date JAN_01_2012_11PM_UTC_AS_DATE = JAN(1, 2012).at(23, TimeZones.UTC_AS_TZ);
+	public static final Date JAN_02_2012_11AM_UTC_AS_DATE = JAN(2, 2012).at(11, TimeZones.UTC_AS_TZ);
+	public static final Date JAN_03_2012_11AM_UTC_AS_DATE = JAN(3, 2012).at(11, TimeZones.UTC_AS_TZ);
+	public static final Date JAN_04_2012_11AM_UTC_AS_DATE = JAN(4, 2012).at(11, TimeZones.UTC_AS_TZ);
+	public static final Date JAN_05_2012_11AM_UTC_AS_DATE = JAN(5, 2012).at(11, TimeZones.UTC_AS_TZ);
+	public static final Date JAN_06_2012_11AM_UTC_AS_DATE = JAN(6, 2012).at(11, TimeZones.UTC_AS_TZ);
+	public static final Date JAN_07_2012_11AM_UTC_AS_DATE = JAN(7, 2012).at(11, TimeZones.UTC_AS_TZ);
+	public static final Date JAN_08_2012_11AM_UTC_AS_DATE = JAN(8, 2012).at(11, TimeZones.UTC_AS_TZ);
+	public static final Date JAN_31_2012_11AM_UTC_AS_DATE = JAN(31, 2012).at(11, TimeZones.UTC_AS_TZ);
+	public static final Date FEB_01_2012_11AM_UTC_AS_DATE = FEB(1, 2012).at(11, TimeZones.UTC_AS_TZ);
+	public static final Date MAR_01_2012_11AM_UTC_AS_DATE = MAR(1, 2012).at(11, TimeZones.UTC_AS_TZ);
+	public static final Date APR_01_2012_11AM_UTC_AS_DATE = APR(1, 2012).at(11, TimeZones.UTC_AS_TZ);
+	public static final Date MAY_01_2012_11AM_UTC_AS_DATE = MAY(1, 2012).at(11, TimeZones.UTC_AS_TZ);
+	public static final Date JUN_01_2012_11AM_UTC_AS_DATE = JUN(1, 2012).at(11, TimeZones.UTC_AS_TZ);
+	public static final Date JUN_15_2012_11AM_UTC_AS_DATE = JUN(15, 2012).at(11, TimeZones.UTC_AS_TZ);
+	public static final Date JUN_15_2012_11PM_UTC_AS_DATE = JUN(15, 2012).at(23, TimeZones.UTC_AS_TZ);
+	public static final Date JUL_01_2012_11AM_UTC_AS_DATE = JUL(1, 2012).at(11, TimeZones.UTC_AS_TZ);
+	public static final Date AUG_01_2012_11AM_UTC_AS_DATE = AUG(1, 2012).at(11, TimeZones.UTC_AS_TZ);
+	public static final Date SEP_01_2012_11AM_UTC_AS_DATE = SEP(1, 2012).at(11, TimeZones.UTC_AS_TZ);
+	public static final Date OCT_01_2012_11AM_UTC_AS_DATE = OCT(1, 2012).at(11, TimeZones.UTC_AS_TZ);
+	public static final Date NOV_01_2012_11AM_UTC_AS_DATE = NOV(1, 2012).at(11, TimeZones.UTC_AS_TZ);
+	public static final Date DEC_01_2012_11AM_UTC_AS_DATE = DEC(1, 2012).at(11, TimeZones.UTC_AS_TZ);
+	public static final Date JAN_01_2013_11AM_UTC_AS_DATE = JAN(1, 2013).at(11, TimeZones.UTC_AS_TZ);
+	public static final Date JAN_01_2100_11AM_UTC_AS_DATE = JAN(1, 2100).at(11, TimeZones.UTC_AS_TZ);
+	public static final Date JAN_01_2015_NOON_UTC_AS_DATE = JAN(1, 2015).at(12, TimeZones.UTC_AS_TZ);
+	public static final Date FEB_01_2015_NOON_UTC_AS_DATE = FEB(1, 2015).at(12, TimeZones.UTC_AS_TZ);
+	public static final Date MAR_01_2015_NOON_UTC_AS_DATE = MAR(1, 2015).at(12, TimeZones.UTC_AS_TZ);
+	public static final Date APR_01_2015_NOON_UTC_AS_DATE = APR(1, 2015).at(12, TimeZones.UTC_AS_TZ);
+	public static final Date MAY_01_2015_NOON_UTC_AS_DATE = MAY(1, 2015).at(12, TimeZones.UTC_AS_TZ);
+	public static final Date JUN_01_2015_NOON_UTC_AS_DATE = JUN(1, 2015).at(12, TimeZones.UTC_AS_TZ);
+	public static final Date JUL_01_2015_NOON_UTC_AS_DATE = JUL(1, 2015).at(12, TimeZones.UTC_AS_TZ);
+	public static final Date AUG_01_2015_NOON_UTC_AS_DATE = AUG(1, 2015).at(12, TimeZones.UTC_AS_TZ);
+	public static final Date AUG_03_2015_NOON_UTC_AS_DATE = AUG(3, 2015).at(12, TimeZones.UTC_AS_TZ);
+	public static final Date AUG_04_2015_1159_UTC_AS_DATE = AUG(4, 2015).at(11, 59, TimeZones.UTC_AS_TZ);
+	public static final Date AUG_04_2015_NOON_UTC_AS_DATE = AUG(4, 2015).at(12, TimeZones.UTC_AS_TZ);
+	public static final Date AUG_04_2015_1201_UTC_AS_DATE = AUG(4, 2015).at(12, 1, TimeZones.UTC_AS_TZ);
+	public static final Date AUG_05_2015_NOON_UTC_AS_DATE = AUG(5, 2015).at(12, TimeZones.UTC_AS_TZ);
+	public static final Date AUG_06_2015_NOON_UTC_AS_DATE = AUG(6, 2015).at(12, TimeZones.UTC_AS_TZ);
+	public static final Date AUG_07_2015_NOON_UTC_AS_DATE = AUG(7, 2015).at(12, TimeZones.UTC_AS_TZ);
+	public static final Date AUG_31_2015_NOON_UTC_AS_DATE = AUG(31, 2015).at(12, TimeZones.UTC_AS_TZ);
+	public static final Date SEP_04_2015_NOON_UTC_AS_DATE = SEP(4, 2015).at(12, TimeZones.UTC_AS_TZ);
+	public static final Date SEP_01_2015_NOON_UTC_AS_DATE = SEP(1, 2015).at(12, TimeZones.UTC_AS_TZ);
+	public static final Date OCT_01_2015_NOON_UTC_AS_DATE = OCT(1, 2015).at(12, TimeZones.UTC_AS_TZ);
+	public static final Date NOV_01_2015_NOON_UTC_AS_DATE = NOV(1, 2015).at(12, TimeZones.UTC_AS_TZ);
+	public static final Date DEC_01_2015_NOON_UTC_AS_DATE = DEC(1, 2015).at(12, TimeZones.UTC_AS_TZ);
+	public static final Date AUG_04_2016_NOON_UTC_AS_DATE = AUG(4, 2016).at(12, TimeZones.UTC_AS_TZ);
+	public static final Date AUG_03_2015_MIDNIGHT_UTC_AS_DATE = AUG(3, 2015).at(0, TimeZones.UTC_AS_TZ);
+	public static final Date AUG_05_2015_MIDNIGHT_UTC_AS_DATE = AUG(5, 2015).at(0, TimeZones.UTC_AS_TZ);
+	public static final Date SEP_04_2015_MIDNIGHT_UTC_AS_DATE = SEP(4, 2015).at(0, TimeZones.UTC_AS_TZ);
+	public static final Date AUG_04_2016_MIDNIGHT_UTC_AS_DATE = AUG(4, 2016).at(0, TimeZones.UTC_AS_TZ);
 
+	public static final Date JAN_01_2012_MIDNIGHT_GMT_AS_DATE = JAN(1, 2012).at(0, GMT_AS_TZ);
+	public static final Date JAN_01_2012_MIDNIGHT_PST_AS_DATE = JAN(1, 2012).at(0, PST_AS_TZ);
+	public static final Date JAN_01_2012_MIDNIGHT_CET_AS_DATE = JAN(1, 2012).at(0, CET_AS_TZ);
 	public static final Date JAN_01_2012_11AM_GMT_AS_DATE = JAN(1, 2012).at(11, GMT_AS_TZ);
 	public static final Date JAN_01_2012_11AM_PST_AS_DATE = JAN(1, 2012).at(11, PST_AS_TZ);
-	public static final Date AUG_03_2015_NOON_UTC_AS_DATE = AUG(3, 2015).at(12, UTC_AS_TZ);
-	public static final Date AUG_04_2015_1159_UTC_AS_DATE = AUG(4, 2015).at(11, 59, UTC_AS_TZ);
+	public static final Date JAN_01_2012_11AM_CET_AS_DATE = JAN(1, 2012).at(11, CET_AS_TZ);
 	public static final Date AUG_04_2015_NOON_CET_AS_DATE = AUG(4, 2015).at(12, CET_AS_TZ);
-	public static final Date AUG_04_2015_NOON_UTC_AS_DATE = AUG(4, 2015).at(12, UTC_AS_TZ);
 	public static final Date AUG_04_2015_NOON_EST_AS_DATE = AUG(4, 2015).at(12, EST_AS_TZ);
-	public static final Date AUG_04_2015_1201_UTC_AS_DATE = AUG(4, 2015).at(12, 1, UTC_AS_TZ);
-	public static final Date AUG_04_2016_NOON_UTC_AS_DATE = AUG(4, 2016).at(12, UTC_AS_TZ);
-	public static final Date SEP_04_2015_NOON_UTC_AS_DATE = SEP(4, 2015).at(12, UTC_AS_TZ);
-	public static final Date AUG_05_2015_NOON_UTC_AS_DATE = AUG(5, 2015).at(12, UTC_AS_TZ);
+
+	public static final Date AUG_04_2015_1159_DEFAULT_AS_DATE = AUG(4, 2015).at(11, 59, TimeZone.getDefault());
 
 	// LocalDate
+	public static final LocalDate JAN_01_2012 = LocalDate.of(2012, Month.JANUARY, 1);
 	public static final LocalDate JUN_14_2012 = LocalDate.of(2012, Month.JUNE, 14);
 	public static final LocalDate JUN_15_2012 = LocalDate.of(2012, Month.JUNE, 15);
 	public static final LocalDate JUN_16_2012 = LocalDate.of(2012, Month.JUNE, 16);
@@ -115,6 +113,7 @@ public abstract class Dates {
 	public static final LocalDate AUG_04_2016 = LocalDate.of(2016, Month.AUGUST, 4);
 
 	// LocalDateTime
+	public static final LocalDateTime JAN_01_2012_MIDNIGHT = LocalDateTime.of(JAN_01_2012, MIDNIGHT);
 	public static final LocalDateTime JUN_14_2012_NOON = LocalDateTime.of(JUN_14_2012, NOON);
 	public static final LocalDateTime JUN_15_2012_11AM = LocalDateTime.of(JUN_15_2012, LocalTime.of(11, 0));
 	public static final LocalDateTime JUN_15_2012_NOON = LocalDateTime.of(JUN_15_2012, NOON);
@@ -145,6 +144,7 @@ public abstract class Dates {
 	public static final LocalDateTime DEC_01_2015_NOON = LocalDateTime.of(DEC_01_2015, NOON);
 	public static final LocalDateTime AUG_04_2016_NOON = LocalDateTime.of(AUG_04_2016, NOON);
 
+	public static final ZonedDateTime JAN_01_2012_MIDNIGHT_CET = ZonedDateTime.of(JAN_01_2012_MIDNIGHT, ZoneIds.CET);
 	public static final ZonedDateTime JUN_14_2012_NOON_UTC = ZonedDateTime.of(JUN_14_2012_NOON, ZoneIds.UTC);
 	public static final ZonedDateTime JUN_15_2012_11AM_UTC = ZonedDateTime.of(JUN_15_2012_11AM, ZoneIds.UTC);
 	public static final ZonedDateTime JUN_15_2012_NOON_UTC = ZonedDateTime.of(JUN_15_2012_NOON, ZoneIds.UTC);

--- a/src/test/java/org/exparity/hamcrest/date/testutils/ZoneIds.java
+++ b/src/test/java/org/exparity/hamcrest/date/testutils/ZoneIds.java
@@ -1,6 +1,3 @@
-/**
- *
- */
 package org.exparity.hamcrest.date.testutils;
 
 import java.time.ZoneId;
@@ -12,8 +9,9 @@ import java.time.ZoneId;
  */
 public abstract class ZoneIds {
 
-	public static final ZoneId UTC = ZoneId.of("UTC");
-	public static final ZoneId CET = ZoneId.of("Europe/Paris");
-	public static final ZoneId EST = ZoneId.of("America/New_York");
+	public static final ZoneId GMT = ZoneId.of("GMT"); // 00:00
+	public static final ZoneId UTC = ZoneId.of("UTC"); // 00:00
+	public static final ZoneId CET = ZoneId.of("Europe/Paris"); // +01:00
+	public static final ZoneId EST = ZoneId.of("America/New_York"); // -04:00
 
 }


### PR DESCRIPTION
* Fixes issue #20 (DateMatchers.isDay(int, Month, int) not adapted for non-zero time zones)

*  #20 - Support for time zones in temporal fields matchers

* #20 merge request review (removed IDE files)

* #20 merge request review (added javadoc)